### PR TITLE
change return type of `Solver_dispatcher.solver_type_of_string`, add

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -25,15 +25,8 @@ type prove_mode =
   | Incremental
 
 let solver_conv =
-  Cmdliner.Arg.enum
-    [ ("z3", Z3_solver)
-    ; ("Z3", Z3_solver)
-    ; ("c2", Colibri2_solver)
-    ; ("colibri2", Colibri2_solver)
-    ; ("Colibri2", Colibri2_solver)
-    ; ("bitwuzla", Bitwuzla_solver)
-    ; ("cvc5", Cvc5_solver)
-    ]
+  Cmdliner.Arg.conv
+    (Solver_dispatcher.solver_type_of_string, Solver_dispatcher.pp_solver_type)
 
 let prove_mode_conv =
   Cmdliner.Arg.enum

--- a/lib/solver_dispatcher.ml
+++ b/lib/solver_dispatcher.ml
@@ -11,10 +11,17 @@ let mappings_of_solver : solver_type -> (module Mappings_intf.S) = function
   | Colibri2_solver -> (module Colibri2_mappings)
   | Bitwuzla_solver -> (module Bitwuzla_mappings)
 
-let solver_type_of_string (s : string) : (solver_type, string) result =
+let solver_type_of_string (s : string) :
+  (solver_type, [> `Msg of string ]) result =
   match String.map Char.lowercase_ascii s with
   | "z3" -> Ok Z3_solver
   | "colibri2" -> Ok Colibri2_solver
   | "bitwuzla" -> Ok Bitwuzla_solver
   | "cvc5" -> Ok Cvc5_solver
-  | s -> Format.ksprintf Result.error "unknown solver %s" s
+  | s -> Error (`Msg (Format.sprintf "unknown solver %s" s))
+
+let pp_solver_type fmt = function
+  | Z3_solver -> Format.fprintf fmt "Z3"
+  | Cvc5_solver -> Format.fprintf fmt "CVC5"
+  | Colibri2_solver -> Format.fprintf fmt "Colibri2"
+  | Bitwuzla_solver -> Format.fprintf fmt "Bitwuzla"


### PR DESCRIPTION
`Solver_dispatcher.pp_solver_type` for easy use with cmdliner