### PR TITLE
Leak bitwuzla TermManager

### DIFF
--- a/.github/workflows/test-bitwuzla.yml
+++ b/.github/workflows/test-bitwuzla.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: "4.14"
-          dune-cache: true
+          dune-cache: false
           allow-prerelease-opam: true
 
       - name: Install dependencies

--- a/lib/bitwuzla_mappings.default.ml
+++ b/lib/bitwuzla_mappings.default.ml
@@ -20,6 +20,8 @@ include Mappings_intf
 
 let _debug = false
 
+let leaky_list = ref []
+
 module Fresh_bitwuzla (B : Bitwuzla_cxx.S) : M = struct
   open B
 
@@ -411,7 +413,13 @@ end
 
 include (
   Mappings.Make (struct
-    module Make () = Fresh_bitwuzla (Bitwuzla_cxx.Make ())
+    module Make () = struct
+      let bitwuzla = (module Bitwuzla_cxx.Make () : Bitwuzla_cxx.S)
+
+      let () = leaky_list := bitwuzla :: !leaky_list
+
+      include Fresh_bitwuzla ((val bitwuzla))
+    end
 
     let is_available = true
 


### PR DESCRIPTION
Leak new Bitwuzla modules to avoid having `TermManagers` collected prematurely. This is a hack  while we wait for a solution in bitwuzla/ocaml-bitwuzla#7 

Also try to close #159 by not caching in `test-bitwuzla`