### PR TITLE
Add conflicts on solvers versions outside depopt range

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,15 +22,24 @@
  (synopsis "A Front-end library for SMT solvers in OCaml")
  (description "A Multi Back-end Front-end for SMT Solvers in OCaml.")
  ; Optional solver dependencies
+ ; Change here sould be mirrored in "conflicts"
  (depopts
   (z3
    (and
     (>= "4.12.2")
-    (<= "4.13")))
+    (< "4.14")))
   colibri2
   (bitwuzla-cxx
    (>= "0.4.0"))
   cvc5)
+ (conflicts
+  (z3
+   (or
+    (< "4.12.2")
+    (>= "4.14")))
+   (bitwuzla-cxx
+    (< "0.4.0"))
+ )
  (depends
   dune
   (ocaml

--- a/smtml.opam
+++ b/smtml.opam
@@ -20,10 +20,14 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5.0"}
 ]
 depopts: [
-  "z3" {>= "4.12.2" & <= "4.13"}
+  "z3" {>= "4.12.2" & < "4.14"}
   "colibri2"
   "bitwuzla-cxx" {>= "0.4.0"}
   "cvc5"
+]
+conflicts: [
+  "z3" {< "4.12.2" | >= "4.14"}
+  "bitwuzla-cxx" {< "0.4.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
We want to nudge our users to install versions of the solvers that are actually compatible with smtml. To this end, I added a conflict with solver versions that are outside of the depopt range.