### PR TITLE
Use named arguments in sub-commands (inspired by OCamlPro/owi#461)

### DIFF
--- a/bench/runner/tool.ml
+++ b/bench/runner/tool.ml
@@ -34,14 +34,14 @@ let pp_prover fmt = function
 
 let prover_to_string = Fmt.str "%a" pp_prover
 
-let is_available = function
-  | Z3 -> Smtml.Solver_dispatcher.is_available Z3_solver
-  | Smtml { name = Bitwuzla; _ } ->
-    Smtml.Solver_dispatcher.is_available Bitwuzla_solver
-  | Smtml { name = Cvc5; _ } -> Smtml.Solver_dispatcher.is_available Cvc5_solver
-  | Smtml { name = Colibri2; _ } ->
-    Smtml.Solver_dispatcher.is_available Colibri2_solver
-  | Smtml { name = Z3; _ } -> Smtml.Solver_dispatcher.is_available Z3_solver
+let is_available =
+  let open Smtml in
+  function
+  | Z3 -> Solver_type.is_available Z3_solver
+  | Smtml { name = Bitwuzla; _ } -> Solver_type.is_available Bitwuzla_solver
+  | Smtml { name = Cvc5; _ } -> Solver_type.is_available Cvc5_solver
+  | Smtml { name = Colibri2; _ } -> Solver_type.is_available Colibri2_solver
+  | Smtml { name = Z3; _ } -> Solver_type.is_available Z3_solver
 
 let cmd ?from_file prover files =
   match prover with

--- a/bin/cmd_run.ml
+++ b/bin/cmd_run.ml
@@ -1,0 +1,120 @@
+open Smtml
+
+let get_solver debug solver_type solver_mode =
+  let module Mappings : Mappings.S_with_fresh =
+    (val Solver_type.to_mappings solver_type)
+  in
+  Mappings.set_debug debug;
+  match solver_mode with
+  | Solver_mode.Batch -> (module Solver.Batch (Mappings) : Solver.S)
+  | Cached -> (module Solver.Cached (Mappings))
+  | Incremental -> (module Solver.Incremental (Mappings))
+
+(* FIXME: this function has a sad name *)
+let parse_file filename =
+  let open Smtml_prelude.Result in
+  let+ lines = Bos.OS.File.read_lines filename in
+  (* FIXME: this can be improved *)
+  let files =
+    List.fold_left
+      (fun acc line ->
+        let line = String.trim line in
+        (* Assume '#' at the start of a line is a comment *)
+        if String.starts_with ~prefix:"#" line then acc else Fpath.v line :: acc )
+      [] lines
+  in
+  List.rev files
+
+let run ~debug ~dry ~print_statistics ~solver_type ~solver_mode ~from_file
+  ~filenames =
+  if debug then Logs.Src.set_level Log.src (Some Logs.Debug);
+  Logs.set_reporter @@ Logs.format_reporter ();
+  let module Solver = (val get_solver debug solver_type solver_mode) in
+  let module Interpret = Interpret.Make (Solver) in
+  let total_tests = ref 0 in
+  let total_t = ref 0. in
+  let exception_log = ref [] in
+  let exception_count = ref 0 in
+  let run_file state file =
+    Log.debug (fun k -> k "File %a..." Fpath.pp file);
+    incr total_tests;
+    let start_t = Unix.gettimeofday () in
+    Fun.protect ~finally:(fun () ->
+      if print_statistics then (
+        let exec_t = Unix.gettimeofday () -. start_t in
+        total_t := !total_t +. exec_t;
+        Log.app (fun m -> m "Run %a in %.06f" Fpath.pp file exec_t) ) )
+    @@ fun () ->
+    let ast =
+      try Ok (Compile.until_rewrite file)
+      with Parse.Syntax_error err -> Error (`Parsing_error (file, err))
+    in
+    match ast with
+    | Ok _ when dry -> state
+    | Ok ast -> Some (Interpret.start ?state ast)
+    | Error (`Parsing_error err) ->
+      Log.err (fun k -> k "Error while parsing %a" Fpath.pp file);
+      incr exception_count;
+      exception_log := err :: !exception_log;
+      state
+  in
+  let run_dir prev_state d =
+    let result =
+      Bos.OS.Dir.fold_contents ~traverse:`Any
+        (fun path state ->
+          if Fpath.has_ext ".smt2" path then run_file state path else state )
+        prev_state d
+    in
+    match result with Error (`Msg e) -> failwith e | Ok state -> state
+  in
+  let run_path prev_state path =
+    match Fpath.to_string path with
+    | "-" -> run_file prev_state path
+    | _ -> (
+      match Bos.OS.Path.exists path with
+      | Ok false ->
+        Log.warn (fun k -> k "%a: No such file or directory" Fpath.pp path);
+        prev_state
+      | Ok true ->
+        if Sys.is_directory (Fpath.to_string path) then run_dir prev_state path
+        else run_file prev_state path
+      | Error (`Msg err) ->
+        Log.err (fun k -> k "%s" err);
+        prev_state )
+  in
+  let _ =
+    match from_file with
+    | None -> List.fold_left run_path None filenames
+    | Some file -> (
+      match parse_file file with
+      | Error (`Msg err) ->
+        Log.err (fun k -> k "%s" err);
+        None
+      | Ok files -> List.fold_left run_file None files )
+  in
+  if print_statistics then Log.app (fun k -> k "total time: %.06f" !total_t);
+  let write_exception_log = function
+    | [] -> Ok ()
+    | exns ->
+      let total = !total_tests in
+      let exceptions = !exception_count in
+      assert (total > 0);
+      let percentage = float exceptions /. float total *. 100.0 in
+      let log_fpath = Fpath.v "exceptions.log" in
+      Bos.OS.File.writef log_fpath
+        "Total tests: %d@\n\
+         Exceptions: %d@\n\
+         Exception percentage: %.2f%%@\n\
+         @\n\
+         %a"
+        total exceptions percentage
+        (Fmt.list
+           ~sep:(fun fmt () -> Fmt.pf fmt "@\n@\n")
+           (fun fmt (path, err) ->
+             Fmt.pf fmt "File: %a@\nError: %s" Fpath.pp path err ) )
+        exns
+  in
+  match write_exception_log !exception_log with
+  | Error (`Msg err) ->
+    Log.warn (fun k -> k "Could not write excptions log: %s" err)
+  | Ok () -> ()

--- a/bin/cmd_to_smt2.ml
+++ b/bin/cmd_to_smt2.ml
@@ -1,0 +1,15 @@
+open Smtml
+
+let run ~debug ~solver_type ~filename =
+  let module Mappings : Mappings_intf.S_with_fresh =
+    (val Solver_type.to_mappings solver_type)
+  in
+  Mappings.set_debug debug;
+  let ast = Parse.from_file filename in
+  let assertions =
+    List.filter_map (function Ast.Assert e -> Some e | _ -> None) ast
+  in
+  let name = Fpath.to_string @@ Fpath.base filename in
+  Format.printf "%a"
+    (Mappings.Smtlib.pp ~name ?logic:None ?status:None)
+    assertions

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -15,148 +15,21 @@
 (* You should have received a copy of the GNU General Public License       *)
 (* along with this program.  If not, see <https://www.gnu.org/licenses/>.  *)
 (***************************************************************************)
-
-open Smtml
-open Solver_dispatcher
-
-let get_solver debug solver prover_mode =
-  let module Mappings = (val mappings_of_solver solver : Mappings.S_with_fresh)
-  in
-  Mappings.set_debug debug;
-  match prover_mode with
-  | Options.Batch -> (module Solver.Batch (Mappings) : Solver.S)
-  | Cached -> (module Solver.Cached (Mappings))
-  | Incremental -> (module Solver.Incremental (Mappings))
-
-(* FIXME: this function has a sad name *)
-let parse_file filename =
-  let open Smtml_prelude.Result in
-  let+ lines = Bos.OS.File.read_lines filename in
-  (* FIXME: this can be improved *)
-  let files =
-    List.fold_left
-      (fun acc line ->
-        let line = String.trim line in
-        (* Assume '#' at the start of a line is a comment *)
-        if String.starts_with ~prefix:"#" line then acc else Fpath.v line :: acc )
-      [] lines
-  in
-  List.rev files
-
-let run debug solver prover_mode dry print_statistics from_file files =
-  if debug then Logs.Src.set_level Log.src (Some Logs.Debug);
-  Logs.set_reporter @@ Logs.format_reporter ();
-  let module Solver = (val get_solver debug solver prover_mode) in
-  let module Interpret = Interpret.Make (Solver) in
-  let total_tests = ref 0 in
-  let total_t = ref 0. in
-  let exception_log = ref [] in
-  let exception_count = ref 0 in
-  let run_file state file =
-    Log.debug (fun k -> k "File %a..." Fpath.pp file);
-    incr total_tests;
-    let start_t = Unix.gettimeofday () in
-    Fun.protect ~finally:(fun () ->
-      if print_statistics then (
-        let exec_t = Unix.gettimeofday () -. start_t in
-        total_t := !total_t +. exec_t;
-        Log.app (fun m -> m "Run %a in %.06f" Fpath.pp file exec_t) ) )
-    @@ fun () ->
-    let ast =
-      try Ok (Compile.until_rewrite file)
-      with Parse.Syntax_error err -> Error (`Parsing_error (file, err))
-    in
-    match ast with
-    | Ok _ when dry -> state
-    | Ok ast -> Some (Interpret.start ?state ast)
-    | Error (`Parsing_error err) ->
-      Log.err (fun k -> k "Error while parsing %a" Fpath.pp file);
-      incr exception_count;
-      exception_log := err :: !exception_log;
-      state
-  in
-  let run_dir prev_state d =
-    let result =
-      Bos.OS.Dir.fold_contents ~traverse:`Any
-        (fun path state ->
-          if Fpath.has_ext ".smt2" path then run_file state path else state )
-        prev_state d
-    in
-    match result with Error (`Msg e) -> failwith e | Ok state -> state
-  in
-  let run_path prev_state path =
-    match Fpath.to_string path with
-    | "-" -> run_file prev_state path
-    | _ -> (
-      match Bos.OS.Path.exists path with
-      | Ok false ->
-        Log.warn (fun k -> k "%a: No such file or directory" Fpath.pp path);
-        prev_state
-      | Ok true ->
-        if Sys.is_directory (Fpath.to_string path) then run_dir prev_state path
-        else run_file prev_state path
-      | Error (`Msg err) ->
-        Log.err (fun k -> k "%s" err);
-        prev_state )
-  in
-  let _ =
-    match from_file with
-    | None -> List.fold_left run_path None files
-    | Some file -> (
-      match parse_file file with
-      | Error (`Msg err) ->
-        Log.err (fun k -> k "%s" err);
-        None
-      | Ok files -> List.fold_left run_file None files )
-  in
-  if print_statistics then Log.app (fun k -> k "total time: %.06f" !total_t);
-  let write_exception_log = function
-    | [] -> Ok ()
-    | exns ->
-      let total = !total_tests in
-      let exceptions = !exception_count in
-      assert (total > 0);
-      let percentage = float exceptions /. float total *. 100.0 in
-      let log_fpath = Fpath.v "exceptions.log" in
-      Bos.OS.File.writef log_fpath
-        "Total tests: %d@\n\
-         Exceptions: %d@\n\
-         Exception percentage: %.2f%%@\n\
-         @\n\
-         %a"
-        total exceptions percentage
-        (Fmt.list
-           ~sep:(fun fmt () -> Fmt.pf fmt "@\n@\n")
-           (fun fmt (path, err) ->
-             Fmt.pf fmt "File: %a@\nError: %s" Fpath.pp path err ) )
-        exns
-  in
-  match write_exception_log !exception_log with
-  | Error (`Msg err) ->
-    Log.warn (fun k -> k "Could not write excptions log: %s" err)
-  | Ok () -> ()
-
-(* TODO: Remove once dolmen is integrated *)
-let to_smt2 debug solver filename =
-  let module Mappings =
-    (val mappings_of_solver solver : Mappings_intf.S_with_fresh)
-  in
-  Mappings.set_debug debug;
-  let ast = Parse.from_file filename in
-  let assertions =
-    List.filter_map (function Ast.Assert e -> Some e | _ -> None) ast
-  in
-  let name = Fpath.to_string @@ Fpath.base filename in
-  Format.printf "%a"
-    (Mappings.Smtlib.pp ~name ?logic:None ?status:None)
-    assertions
+open Cmdliner
 
 let cli =
-  Cmdliner.Cmd.group
-    (Cmdliner.Cmd.info "smtml" ~version:"%%VERSION%%")
-    [ Options.cmd_run run; Options.cmd_to_smt2 to_smt2 ]
+  let cmd_run = Cmd.v Options.info_run Options.cmd_run in
+  let cmd_to_smt2 = Cmd.v Options.info_to_smt2 Options.cmd_to_smt2 in
+  let info = Cmd.info "smtml" ~version:"%%VERSION%%" in
+  Cmd.group info [ cmd_run; cmd_to_smt2 ]
 
-let () =
+let returncode =
   match Cmdliner.Cmd.eval_value cli with
-  | Error (`Exn | `Parse | `Term) -> exit 2
-  | Ok (`Help | `Ok () | `Version) -> ()
+  | Ok (`Help | `Version | `Ok ()) -> Cmd.Exit.ok
+  | Error e -> (
+    match e with
+    | `Term -> Cmd.Exit.some_error
+    | `Parse -> Cmd.Exit.cli_error
+    | `Exn -> Cmd.Exit.internal_error )
+
+let () = exit returncode

--- a/src/dune
+++ b/src/dune
@@ -40,6 +40,8 @@
   rewrite
   solver
   solver_intf
+  solver_mode
+  solver_type
   solver_dispatcher
   smtlib
   symbol
@@ -52,6 +54,7 @@
  (flags
   (:standard -open Smtml_prelude))
  (libraries
+  cmdliner
   dolmen
   dolmen_type
   hc

--- a/src/solvers/solver_dispatcher.ml
+++ b/src/solvers/solver_dispatcher.ml
@@ -2,13 +2,7 @@
 (* Copyright (C) 2023-2024 formalsec *)
 (* Written by the Smtml programmers *)
 
-(* TODO: put this in some other more appropriate module? *)
-type solver_type =
-  | Z3_solver
-  | Bitwuzla_solver
-  | Colibri2_solver
-  | Cvc5_solver
-  | Altergo_solver
+open Solver_type
 
 let is_available = function
   | Z3_solver -> Z3_mappings.is_available
@@ -17,11 +11,11 @@ let is_available = function
   | Cvc5_solver -> Cvc5_mappings.is_available
   | Altergo_solver -> Altergo_mappings.is_available
 
-let available_solvers =
+let available =
   List.filter is_available
     [ Z3_solver; Bitwuzla_solver; Colibri2_solver; Cvc5_solver ]
 
-let mappings_of_solver : solver_type -> (module Mappings.S_with_fresh) =
+let mappings_of_solver : Solver_type.t -> (module Mappings.S_with_fresh) =
   function
   | Z3_solver -> (module Z3_mappings)
   | Bitwuzla_solver -> (module Bitwuzla_mappings)
@@ -29,23 +23,7 @@ let mappings_of_solver : solver_type -> (module Mappings.S_with_fresh) =
   | Cvc5_solver -> (module Cvc5_mappings)
   | Altergo_solver -> (module Altergo_mappings)
 
-let solver_type_of_string s =
-  match String.map Char.lowercase_ascii s with
-  | "z3" -> Ok Z3_solver
-  | "bitwuzla" -> Ok Bitwuzla_solver
-  | "colibri2" -> Ok Colibri2_solver
-  | "cvc5" -> Ok Cvc5_solver
-  | "alt-ergo" -> Ok Altergo_solver
-  | s -> Error (`Msg (Fmt.str "unknown solver %s" s))
-
 let solver =
-  match available_solvers with
+  match available with
   | [] -> Error (`Msg "no available solver")
   | solver :: _ -> Ok (mappings_of_solver solver)
-
-let pp_solver_type fmt = function
-  | Z3_solver -> Fmt.pf fmt "Z3"
-  | Bitwuzla_solver -> Fmt.pf fmt "Bitwuzla"
-  | Colibri2_solver -> Fmt.pf fmt "Colibri2"
-  | Cvc5_solver -> Fmt.pf fmt "cvc5"
-  | Altergo_solver -> Fmt.pf fmt "Alt-Ergo"

--- a/src/solvers/solver_dispatcher.mli
+++ b/src/solvers/solver_dispatcher.mli
@@ -2,23 +2,13 @@
 (* Copyright (C) 2023-2024 formalsec *)
 (* Written by the Smtml programmers *)
 
-type solver_type =
-  | Z3_solver
-  | Bitwuzla_solver
-  | Colibri2_solver
-  | Cvc5_solver
-  | Altergo_solver
-
-val is_available : solver_type -> bool
+(** Will be deprecated in favour of Solver_type *)
+val is_available : Solver_type.t -> bool
 
 (** List of all available solvers. Can be empty if no solver installed. *)
-val available_solvers : solver_type list
+val available : Solver_type.t list
 
 (** Returns first available solver or errors when none exist *)
 val solver : ((module Mappings.S_with_fresh), [> `Msg of string ]) result
 
-val mappings_of_solver : solver_type -> (module Mappings.S_with_fresh)
-
-val solver_type_of_string : string -> (solver_type, [> `Msg of string ]) result
-
-val pp_solver_type : solver_type Fmt.t
+val mappings_of_solver : Solver_type.t -> (module Mappings.S_with_fresh)

--- a/src/solvers/solver_mode.ml
+++ b/src/solvers/solver_mode.ml
@@ -1,0 +1,21 @@
+(* SPDX-License-Identifier: MIT *)
+(* Copyright (C) 2023-2024 formalsec *)
+(* Written by the Smtml programmers *)
+
+type t =
+  | Batch
+  | Cached
+  | Incremental
+
+let pp fmt = function
+  | Batch -> Fmt.string fmt "batch"
+  | Cached -> Fmt.string fmt "cached"
+  | Incremental -> Fmt.string fmt "incremental"
+
+let of_string = function
+  | "batch" -> Ok Batch
+  | "cached" -> Ok Cached
+  | "incremental" -> Ok Incremental
+  | _mode -> Error (`Msg (Fmt.str "unknown prover mode"))
+
+let conv = Cmdliner.Arg.conv (of_string, pp)

--- a/src/solvers/solver_mode.mli
+++ b/src/solvers/solver_mode.mli
@@ -1,0 +1,14 @@
+(* SPDX-License-Identifier: MIT *)
+(* Copyright (C) 2023-2024 formalsec *)
+(* Written by the Smtml programmers *)
+
+type t =
+  | Batch
+  | Cached
+  | Incremental
+
+val pp : t Fmt.t
+
+val of_string : string -> (t, [> `Msg of string ]) result
+
+val conv : t Cmdliner.Arg.conv

--- a/src/solvers/solver_type.ml
+++ b/src/solvers/solver_type.ml
@@ -1,0 +1,42 @@
+(* SPDX-License-Identifier: MIT *)
+(* Copyright (C) 2023-2024 formalsec *)
+(* Written by the Smtml programmers *)
+
+type t =
+  | Z3_solver
+  | Bitwuzla_solver
+  | Colibri2_solver
+  | Cvc5_solver
+  | Altergo_solver
+
+let of_string s =
+  match String.map Char.lowercase_ascii s with
+  | "z3" -> Ok Z3_solver
+  | "bitwuzla" -> Ok Bitwuzla_solver
+  | "colibri2" -> Ok Colibri2_solver
+  | "cvc5" -> Ok Cvc5_solver
+  | "alt-ergo" -> Ok Altergo_solver
+  | s -> Error (`Msg (Fmt.str "unknown solver %s" s))
+
+let pp fmt = function
+  | Z3_solver -> Fmt.string fmt "Z3"
+  | Bitwuzla_solver -> Fmt.string fmt "Bitwuzla"
+  | Colibri2_solver -> Fmt.string fmt "Colibri2"
+  | Cvc5_solver -> Fmt.string fmt "cvc5"
+  | Altergo_solver -> Fmt.string fmt "Alt-Ergo"
+
+let conv = Cmdliner.Arg.conv (of_string, pp)
+
+let is_available = function
+  | Z3_solver -> Z3_mappings.is_available
+  | Bitwuzla_solver -> Bitwuzla_mappings.is_available
+  | Colibri2_solver -> Colibri2_mappings.is_available
+  | Cvc5_solver -> Cvc5_mappings.is_available
+  | Altergo_solver -> Altergo_mappings.is_available
+
+let to_mappings : t -> (module Mappings.S_with_fresh) = function
+  | Z3_solver -> (module Z3_mappings)
+  | Bitwuzla_solver -> (module Bitwuzla_mappings)
+  | Colibri2_solver -> (module Colibri2_mappings)
+  | Cvc5_solver -> (module Cvc5_mappings)
+  | Altergo_solver -> (module Altergo_mappings)

--- a/src/solvers/solver_type.mli
+++ b/src/solvers/solver_type.mli
@@ -1,0 +1,20 @@
+(* SPDX-License-Identifier: MIT *)
+(* Copyright (C) 2023-2024 formalsec *)
+(* Written by the Smtml programmers *)
+
+type t =
+  | Z3_solver
+  | Bitwuzla_solver
+  | Colibri2_solver
+  | Cvc5_solver
+  | Altergo_solver
+
+val of_string : string -> (t, [> `Msg of string ]) result
+
+val pp : t Fmt.t
+
+val conv : t Cmdliner.Arg.conv
+
+val is_available : t -> bool
+
+val to_mappings : t -> (module Mappings.S_with_fresh)

--- a/test/smt2/test_smt2.t
+++ b/test/smt2/test_smt2.t
@@ -3,7 +3,7 @@ Test parsing a nonexistent file:
   smtml: FILES… arguments: no 'idontexist.smt2' file or directory
   Usage: smtml run [OPTION]… [FILES]…
   Try 'smtml run --help' or 'smtml --help' for more information.
-  [2]
+  [124]
 
 Test parsing an empty file:
   $ smtml run test_empty.smt2


### PR DESCRIPTION
As inspired by OCamlPro/owi#461:

- use cmdliner's monadic syntax to build cmd terms;
- use named arguments in the cmds functions.

Other changes include:

- Moving sub-commands into respective `cmd_<command_name>.ml` modules;
- Creating a `Solver_mode` module;
- Moving most functions from `Solver_dispatcher` into a more appropriate `Solver_type` module
- Explicit exit codes for Term, Parse, and Exn error outputs in cmdliner.