### PR TITLE
Bring Owi's missing simplifications into `extract2` and `concat3`

### DIFF
--- a/src/expr.mli
+++ b/src/expr.mli
@@ -107,11 +107,15 @@ val extract : t -> high:int -> low:int -> t
 (** Dumb extract constructor, no simplifications *)
 val extract' : t -> high:int -> low:int -> t
 
+val extract2 : t -> int -> t
+
 (** Smart concat constructor, applies simplifications at constructor level *)
 val concat : t -> t -> t
 
 (** Dumb concat constructor, no simplifications *)
 val concat' : t -> t -> t
+
+val concat3 : msb:t -> lsb:t -> int -> t
 
 (** Applies expression simplifications until a fixpoint *)
 val simplify : t -> t


### PR DESCRIPTION
Closes #195 

PR #284 will address the remaining missing concrete extract and concat simplifications. As well as, integrating `extract2` into `extract` and `concat3` into `concat` 