### PR TITLE
Add a message to concrete eval's `TypeError` (closes #321)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Add a message to concrete eval's `TypeError` (closes #321)
 - Add `popcnt` implementation (@zapashcanon)
 
 ## v0.6.2

--- a/src/smtml/eval.mli
+++ b/src/smtml/eval.mli
@@ -39,6 +39,7 @@ exception
     ; value : Value.t  (** The actual value that caused the error. *)
     ; ty : Ty.t  (** The expected type. *)
     ; op : op_type  (** The operation that led to the error. *)
+    ; msg : string
     }
 (* FIXME: use snake case instead *)
 

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -11,7 +11,7 @@ let pp_op fmt = function
 
 let with_type_error f =
   try f ()
-  with Eval.TypeError { index; value; ty; op } ->
+  with Eval.TypeError { index; value; ty; op; _ } ->
     Fmt.failwith
       "type error: operator %a.%a argument %d got unexpected value %a" Ty.pp ty
       pp_op op index Value.pp value


### PR DESCRIPTION
On the example:

```
stack        : [ 0 ]
running instr: i64.extend_i32_s
owi: internal error, uncaught exception:
     Smtml.Eval.TypeError(1, _, _, _, "Argument 1 of cvtop 'extend_i32_s' expected type i32 but got int instead.")
     Raised at Stdlib__Domain.join in file "domain.ml", line 299, characters 16-24
     Called from Stdlib__Array.iter in file "array.ml", line 113, characters 31-48
     Called from Owi__Wq.read_as_seq.(fun) in file "src/data_structures/wq.ml", line 17, characters 4-16
     Called from Owi__Cmd_sym.print_and_count_failures.aux in file "src/cmd/cmd_sym.ml", line 118, characters 10-20
     Called from Owi__Cmd_sym.handle_result in file "src/cmd/cmd_sym.ml", lines 184-186, characters 4-45
     Called from Stdlib__List.fold_left in file "list.ml", line 123, characters 24-34
     Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 24, characters 19-24
     Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 35, characters 37-44
Checking export func_98_invoker
```