### PR TITLE
implement function to_ieee_bv for Bitwuzla

### DIFF
--- a/src/smtml/bitwuzla_mappings.default.ml
+++ b/src/smtml/bitwuzla_mappings.default.ml
@@ -407,8 +407,29 @@ module Fresh_bitwuzla (B : Bitwuzla_cxx.S) : M = struct
     let of_ieee_bv eb sb bv = mk_term1_indexed2 Kind.Fp_to_fp_from_bv bv eb sb
 
     (* TODO *)
-    let to_ieee_bv _ =
-      Fmt.failwith "Bitwuzla_mappings: to_ieee_bv not implemented"
+    let to_ieee_bv x (* x : Term.IEEE_754 -> Term.Z *) =
+      let (sign,exp,mant) = match Term.kind x with
+        | Kind.Fp_fp ->
+           begin match x with
+           | Term.IEEE_754 (x,y,z) -> (x,y,z)
+           | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem"
+           end
+        | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem"
+      in
+      let v = (Float.pow 2. exp) *. mant *. (Float.pow (-1.) sign) in
+      mk_bv_value_int (mk_bv_sort 64) (Float.to_int v)
+
+    (*     begin match Term.children x with *)
+    (*       | [|x;y;z|] -> (x,y,z) *)
+    (*       | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem" *)
+    (*     end *)
+    (* | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem" *)
+    (* in *)
+    (* let xx = Term.value x in *)
+    (* let v = (Float.pow 2. exp) *. mant *. (Float.pow (-1.) sign) in *)
+    (* mk_bv_value_int (mk_bv_sort 64) (Float.to_int v) *)
+
+    (* Fmt.failwith "Bitwuzla_mappings: to_ieee_bv not implemented" *)
   end
 
   module Func = struct

--- a/src/smtml/bitwuzla_mappings.default.ml
+++ b/src/smtml/bitwuzla_mappings.default.ml
@@ -407,29 +407,35 @@ module Fresh_bitwuzla (B : Bitwuzla_cxx.S) : M = struct
     let of_ieee_bv eb sb bv = mk_term1_indexed2 Kind.Fp_to_fp_from_bv bv eb sb
 
     (* TODO *)
-    let to_ieee_bv x (* x : Term.IEEE_754 -> Term.Z *) =
-      let (sign,exp,mant) = match Term.kind x with
-        | Kind.Fp_fp ->
-           begin match x with
-           | Term.IEEE_754 (x,y,z) -> (x,y,z)
-           | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem"
-           end
-        | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem"
-      in
-      let v = (Float.pow 2. exp) *. mant *. (Float.pow (-1.) sign) in
-      mk_bv_value_int (mk_bv_sort 64) (Float.to_int v)
+    let to_ieee_bv x =
+      let (sign, exp, mant) = Term.value Term.IEEE_754 x in
+      let bits_str = String.concat [sign; exp; mant] in
+      let bv = Z.of_string_base 2 bits_str in
+      let total_bits = String.length bits_str in
+      mk_bv_value_int (mk_bv_sort total_bits) (Float.to_int bv)
 
-    (*     begin match Term.children x with *)
-    (*       | [|x;y;z|] -> (x,y,z) *)
-    (*       | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem" *)
-    (*     end *)
-    (* | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem" *)
-    (* in *)
-    (* let xx = Term.value x in *)
-    (* let v = (Float.pow 2. exp) *. mant *. (Float.pow (-1.) sign) in *)
-    (* mk_bv_value_int (mk_bv_sort 64) (Float.to_int v) *)
+      (* let (sign,exp,mant) = match Term.kind x with *)
+      (*   | Kind.Fp_fp -> *)
+      (*      begin match x with *)
+      (*      | Term.IEEE_754 (x,y,z) -> (x,y,z) *)
+      (*      | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem" *)
+      (*      end *)
+      (*   | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem" *)
+      (* in *)
+      (* let v = (Float.pow 2. exp) *. mant *. (Float.pow (-1.) sign) in *)
+      (* mk_bv_value_int (mk_bv_sort 64) (Float.to_int v) *)
 
-    (* Fmt.failwith "Bitwuzla_mappings: to_ieee_bv not implemented" *)
+      (*     begin match Term.children x with *)
+      (*       | [|x;y;z|] -> (x,y,z) *)
+      (*       | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem" *)
+      (*     end *)
+      (* | _ -> Fmt.failwith "Bitwuzla_mappings: to_ieee_bv problem" *)
+      (* in *)
+      (* let xx = Term.value x in *)
+      (* let v = (Float.pow 2. exp) *. mant *. (Float.pow (-1.) sign) in *)
+      (* mk_bv_value_int (mk_bv_sort 64) (Float.to_int v) *)
+  
+      (* Fmt.failwith "Bitwuzla_mappings: to_ieee_bv not implemented" *)
   end
 
   module Func = struct


### PR DESCRIPTION
I’m working on the to_ieee_bv function to convert a floating-point number to its IEEE-754 bit vector form for Bitwuzla.

Right now, I'm trying to figure out whether I should create a new mk_bv_value_float function in the kind module or if it’s better to just use Bitwuzla’s existing API for this.

I'd love some feedback on:
Should I add mk_bv_value_float, or can I achieve this with the current API?
Any advice on how to handle floating-point to bit vector conversion using Bitwuzla’s tools?
If you have any thoughts on how to improve the implementation, feel free to share!

Thanks for your help!