### PR TITLE
Experiment with safe expressions

### DIFF
--- a/src/smtml/expr.ml
+++ b/src/smtml/expr.ml
@@ -308,6 +308,8 @@ let value (v : Value.t) : t = make (Val v) [@@inline]
 
 let ptr base offset = make (Ptr { base; offset })
 
+let list l = make (List l)
+
 let app symbol args = make (App (symbol, args))
 
 let[@inline] binder bt vars expr = make (Binder (bt, vars, expr))

--- a/src/smtml/expr.mli
+++ b/src/smtml/expr.mli
@@ -14,7 +14,7 @@
 type t = expr Hc.hash_consed
 
 (** The different types of expressions. *)
-and expr =
+and expr = private
   | Val of Value.t  (** A constant value. *)
   | Ptr of
       { base : int32  (** Base address. *)
@@ -34,9 +34,6 @@ and expr =
   | Binder of Binder.t * t list * t  (** A binding expression. *)
 
 (** {1 Constructors and Accessors} *)
-
-(** [make expr] creates a new term from the given expression. *)
-val make : expr -> t
 
 (** [view term] extracts the underlying expression from a term. *)
 val view : t -> expr
@@ -93,6 +90,9 @@ val value : Value.t -> t
     address and offset. *)
 val ptr : int32 -> t -> t
 
+(** [list l] constructs a list expression with the given list of expressions *)
+val list : t list -> t
+
 (** [symbol sym] constructs a symbolic variable expression from the given
     symbol. *)
 val symbol : Symbol.t -> t
@@ -100,6 +100,10 @@ val symbol : Symbol.t -> t
 (** [app sym args] constructs a function application expression with the given
     symbol and arguments. *)
 val app : Symbol.t -> t list -> t
+
+(** [binder ty bindings body] constructs a [ty] bidning expression with the
+    given bindings and body. *)
+val binder : Binder.t -> t list -> t -> t
 
 (** [let_in bindings body] constructs a let-binding expression with the given
     bindings and body. *)

--- a/src/smtml/parser.mly
+++ b/src/smtml/parser.mly
@@ -62,20 +62,28 @@ let s_expr :=
     | None -> assert false
     | Some v -> Expr.symbol (Symbol.make v x)
   }
-  | c = spec_constant; { make (Val c) }
-  | LPAREN; op = paren_op; RPAREN; { make op }
+  | c = spec_constant; { value c }
+  | LPAREN; op = paren_op; RPAREN; { op }
 
 let paren_op :=
   | PTR; LPAREN; _ = TYPE; x = NUM; RPAREN; offset = s_expr;
-    { Ptr { base = Int32.of_int x; offset } }
-  | (ty, op) = UNARY; e = s_expr; <Unop>
-  | (ty, op) = BINARY; e1 = s_expr; e2 = s_expr; <Binop>
-  | (ty, op) = TERNARY; e1 = s_expr; e2 = s_expr; e3 = s_expr; <Triop>
-  | (ty, op) = CVTOP; e = s_expr; <Cvtop>
-  | (ty, op) = RELOP; e1 = s_expr; e2 = s_expr; <Relop>
-  | (ty, op) = NARY; es = list(s_expr); <Naryop>
-  | EXTRACT; ~ = s_expr; l = NUM; h = NUM; { Extract ( s_expr, h, l) }
-  | CONCAT; e1 = s_expr; e2 = s_expr; <Concat>
+    { Expr.ptr (Int32.of_int x) offset }
+  | (ty, op) = UNARY; e = s_expr;
+    { Expr.unop ty op e }
+  | (ty, op) = BINARY; e1 = s_expr; e2 = s_expr;
+    { Expr.binop ty op e1 e2 }
+  | (ty, op) = TERNARY; e1 = s_expr; e2 = s_expr; e3 = s_expr;
+    { Expr.triop ty op e1 e2 e3 }
+  | (ty, op) = CVTOP; e = s_expr;
+    { Expr.cvtop ty op e }
+  | (ty, op) = RELOP; e1 = s_expr; e2 = s_expr;
+    { Expr.relop ty op e1 e2 }
+  | (ty, op) = NARY; es = list(s_expr);
+    { Expr.naryop ty op es }
+  | EXTRACT; ~ = s_expr; l = NUM; h = NUM;
+    { Expr.extract s_expr ~high:h ~low:l }
+  | CONCAT; e1 = s_expr; e2 = s_expr;
+    { Expr.concat e1 e2 }
 
 let spec_constant :=
   | x = NUM; { Int x }

--- a/src/smtml/rewrite.ml
+++ b/src/smtml/rewrite.ml
@@ -45,10 +45,9 @@ let rec rewrite_expr (type_map, expr_map) hte =
       | None -> Fmt.failwith "Undefined symbol: %a" Symbol.pp sym
       | Some expr -> expr )
     | Some ty -> Expr.symbol { sym with ty } )
-  | List htes ->
-    Expr.make (List (List.map (rewrite_expr (type_map, expr_map)) htes))
+  | List htes -> Expr.list (List.map (rewrite_expr (type_map, expr_map)) htes)
   | App (op, htes) ->
-    Expr.make (App (op, List.map (rewrite_expr (type_map, expr_map)) htes))
+    Expr.app op (List.map (rewrite_expr (type_map, expr_map)) htes)
   | Unop (ty, op, hte) ->
     let hte = rewrite_expr (type_map, expr_map) hte in
     let ty = rewrite_ty ty [ Expr.ty hte ] in
@@ -78,7 +77,7 @@ let rec rewrite_expr (type_map, expr_map) hte =
     Expr.cvtop ty op hte
   | Naryop (ty, op, htes) ->
     let htes = List.map (rewrite_expr (type_map, expr_map)) htes in
-    Expr.make (Naryop (ty, op, htes))
+    Expr.naryop ty op htes
   | Extract (hte, h, l) ->
     let hte = rewrite_expr (type_map, expr_map) hte in
     Expr.extract hte ~high:h ~low:l
@@ -112,7 +111,7 @@ let rec rewrite_expr (type_map, expr_map) hte =
           | _ -> assert false )
         (type_map, []) vars
     in
-    Expr.make (Binder (quantifier, vars, rewrite_expr (type_map, expr_map) e))
+    Expr.binder quantifier vars (rewrite_expr (type_map, expr_map) e)
 
 (** Acccumulates types of symbols in [type_map] and calls rewrite_expr *)
 let rewrite_cmd type_map cmd =

--- a/src/smtml/smtlib.ml
+++ b/src/smtml/smtlib.ml
@@ -120,75 +120,75 @@ module Term = struct
     match Expr.view id with
     | Symbol { namespace = Term; name = Simple name; _ } -> (
       match (name, args) with
-      | "-", [ a ] -> Expr.unop' Ty_none Neg a
-      | "not", [ a ] -> Expr.unop' Ty_bool Not a
-      | "and", [ a; b ] -> Expr.binop' Ty_bool And a b
-      | "and", ts -> Expr.naryop' Ty_bool Logand ts
-      | "or", [ a; b ] -> Expr.binop' Ty_bool Or a b
-      | "or", ts -> Expr.naryop' Ty_bool Logor ts
-      | "xor", [ a; b ] -> Expr.binop' Ty_bool Xor a b
-      | "+", [ a; b ] -> Expr.binop' Ty_none Add a b
+      | "-", [ a ] -> Expr.raw_unop Ty_none Neg a
+      | "not", [ a ] -> Expr.raw_unop Ty_bool Not a
+      | "and", [ a; b ] -> Expr.raw_binop Ty_bool And a b
+      | "and", ts -> Expr.raw_naryop Ty_bool Logand ts
+      | "or", [ a; b ] -> Expr.raw_binop Ty_bool Or a b
+      | "or", ts -> Expr.raw_naryop Ty_bool Logor ts
+      | "xor", [ a; b ] -> Expr.raw_binop Ty_bool Xor a b
+      | "+", [ a; b ] -> Expr.raw_binop Ty_none Add a b
       | "+", hd :: tl ->
-        List.fold_left (fun acc hd -> Expr.binop' Ty_none Add acc hd) hd tl
-      | "-", [ a; b ] -> Expr.binop' Ty_none Sub a b
-      | "*", [ a; b ] -> Expr.binop' Ty_none Mul a b
-      | "/", [ a; b ] -> Expr.binop' Ty_none Div a b
-      | "mod", [ a; b ] -> Expr.binop' Ty_none Rem a b
+        List.fold_left (fun acc hd -> Expr.raw_binop Ty_none Add acc hd) hd tl
+      | "-", [ a; b ] -> Expr.raw_binop Ty_none Sub a b
+      | "*", [ a; b ] -> Expr.raw_binop Ty_none Mul a b
+      | "/", [ a; b ] -> Expr.raw_binop Ty_none Div a b
+      | "mod", [ a; b ] -> Expr.raw_binop Ty_none Rem a b
       | "ite", [ a; b; c ] -> Expr.triop Ty_bool Ite a b c
-      | "=", [ a; b ] -> Expr.relop' Ty_bool Eq a b
-      | "distinct", [ a; b ] -> Expr.relop' Ty_bool Ne a b
-      | ">", [ a; b ] -> Expr.relop' Ty_none Gt a b
-      | ">=", [ a; b ] -> Expr.relop' Ty_none Ge a b
-      | "<", [ a; b ] -> Expr.relop' Ty_none Lt a b
-      | "<=", [ a; b ] -> Expr.relop' Ty_none Le a b
-      | "to_real", [ a ] -> Expr.cvtop' Ty_real Reinterpret_int a
-      | "to_int", [ a ] -> Expr.cvtop' Ty_int Reinterpret_float a
-      | "str.len", [ a ] -> Expr.unop' Ty_str Length a
-      | "str.at", [ a; b ] -> Expr.binop' Ty_str At a b
-      | "str.prefixof", [ a; b ] -> Expr.binop' Ty_str String_prefix a b
-      | "str.suffixof", [ a; b ] -> Expr.binop' Ty_str String_suffix a b
-      | "str.contains", [ a; b ] -> Expr.binop' Ty_str String_contains a b
-      | "str.in_re", [ a; b ] -> Expr.binop' Ty_str String_in_re a b
+      | "=", [ a; b ] -> Expr.raw_relop Ty_bool Eq a b
+      | "distinct", [ a; b ] -> Expr.raw_relop Ty_bool Ne a b
+      | ">", [ a; b ] -> Expr.raw_relop Ty_none Gt a b
+      | ">=", [ a; b ] -> Expr.raw_relop Ty_none Ge a b
+      | "<", [ a; b ] -> Expr.raw_relop Ty_none Lt a b
+      | "<=", [ a; b ] -> Expr.raw_relop Ty_none Le a b
+      | "to_real", [ a ] -> Expr.raw_cvtop Ty_real Reinterpret_int a
+      | "to_int", [ a ] -> Expr.raw_cvtop Ty_int Reinterpret_float a
+      | "str.len", [ a ] -> Expr.raw_unop Ty_str Length a
+      | "str.at", [ a; b ] -> Expr.raw_binop Ty_str At a b
+      | "str.prefixof", [ a; b ] -> Expr.raw_binop Ty_str String_prefix a b
+      | "str.suffixof", [ a; b ] -> Expr.raw_binop Ty_str String_suffix a b
+      | "str.contains", [ a; b ] -> Expr.raw_binop Ty_str String_contains a b
+      | "str.in_re", [ a; b ] -> Expr.raw_binop Ty_str String_in_re a b
       | "str.substr", [ a; b; c ] -> Expr.triop Ty_str String_extract a b c
       | "str.indexof", [ a; b; c ] -> Expr.triop Ty_str String_index a b c
       | "str.replace", [ a; b; c ] -> Expr.triop Ty_str String_replace a b c
-      | "str.++", n -> Expr.naryop' Ty_str Concat n
-      | "str.<", [ a; b ] -> Expr.relop' Ty_str Lt a b
-      | "str.<=", [ a; b ] -> Expr.relop' Ty_str Le a b
-      | "str.to_code", [ a ] -> Expr.cvtop' Ty_str String_to_code a
-      | "str.from_code", [ a ] -> Expr.cvtop' Ty_str String_from_code a
-      | "str.to_int", [ a ] -> Expr.cvtop' Ty_str String_to_int a
-      | "str.from_int", [ a ] -> Expr.cvtop' Ty_str String_from_int a
-      | "str.to_re", [ a ] -> Expr.cvtop' Ty_str String_to_re a
-      | "re.*", [ a ] -> Expr.unop' Ty_regexp Regexp_star a
-      | "re.+", [ a ] -> Expr.unop' Ty_regexp Regexp_plus a
-      | "re.opt", [ a ] -> Expr.unop' Ty_regexp Regexp_opt a
-      | "re.comp", [ a ] -> Expr.unop' Ty_regexp Regexp_comp a
-      | "re.range", [ a; b ] -> Expr.binop' Ty_regexp Regexp_range a b
-      | "re.union", n -> Expr.naryop' Ty_regexp Regexp_union n
-      | "re.++", n -> Expr.naryop' Ty_regexp Concat n
-      | "bvnot", [ a ] -> Expr.unop' Ty_none Not a
-      | "bvneg", [ a ] -> Expr.unop' Ty_none Neg a
-      | "bvand", [ a; b ] -> Expr.binop' Ty_none And a b
-      | "bvor", [ a; b ] -> Expr.binop' Ty_none Or a b
-      | "bvxor", [ a; b ] -> Expr.binop' Ty_none Xor a b
-      | "bvadd", [ a; b ] -> Expr.binop' Ty_none Add a b
-      | "bvsub", [ a; b ] -> Expr.binop' Ty_none Sub a b
-      | "bvmul", [ a; b ] -> Expr.binop' Ty_none Mul a b
-      | "bvudiv", [ a; b ] -> Expr.binop' Ty_none DivU a b
-      | "bvurem", [ a; b ] -> Expr.binop' Ty_none RemU a b
-      | "bvshl", [ a; b ] -> Expr.binop' Ty_none Shl a b
-      | "bvlshr", [ a; b ] -> Expr.binop' Ty_none ShrL a b
-      | "bvashr", [ a; b ] -> Expr.binop' Ty_none ShrA a b
-      | "bvslt", [ a; b ] -> Expr.relop' Ty_none Lt a b
-      | "bvult", [ a; b ] -> Expr.relop' Ty_none LtU a b
-      | "bvsle", [ a; b ] -> Expr.relop' Ty_none Le a b
-      | "bvule", [ a; b ] -> Expr.relop' Ty_none LeU a b
-      | "bvsgt", [ a; b ] -> Expr.relop' Ty_none Gt a b
-      | "bvugt", [ a; b ] -> Expr.relop' Ty_none GtU a b
-      | "bvsge", [ a; b ] -> Expr.relop' Ty_none Ge a b
-      | "bvuge", [ a; b ] -> Expr.relop' Ty_none GeU a b
-      | "concat", [ a; b ] -> Expr.concat' a b
+      | "str.++", n -> Expr.raw_naryop Ty_str Concat n
+      | "str.<", [ a; b ] -> Expr.raw_relop Ty_str Lt a b
+      | "str.<=", [ a; b ] -> Expr.raw_relop Ty_str Le a b
+      | "str.to_code", [ a ] -> Expr.raw_cvtop Ty_str String_to_code a
+      | "str.from_code", [ a ] -> Expr.raw_cvtop Ty_str String_from_code a
+      | "str.to_int", [ a ] -> Expr.raw_cvtop Ty_str String_to_int a
+      | "str.from_int", [ a ] -> Expr.raw_cvtop Ty_str String_from_int a
+      | "str.to_re", [ a ] -> Expr.raw_cvtop Ty_str String_to_re a
+      | "re.*", [ a ] -> Expr.raw_unop Ty_regexp Regexp_star a
+      | "re.+", [ a ] -> Expr.raw_unop Ty_regexp Regexp_plus a
+      | "re.opt", [ a ] -> Expr.raw_unop Ty_regexp Regexp_opt a
+      | "re.comp", [ a ] -> Expr.raw_unop Ty_regexp Regexp_comp a
+      | "re.range", [ a; b ] -> Expr.raw_binop Ty_regexp Regexp_range a b
+      | "re.union", n -> Expr.raw_naryop Ty_regexp Regexp_union n
+      | "re.++", n -> Expr.raw_naryop Ty_regexp Concat n
+      | "bvnot", [ a ] -> Expr.raw_unop Ty_none Not a
+      | "bvneg", [ a ] -> Expr.raw_unop Ty_none Neg a
+      | "bvand", [ a; b ] -> Expr.raw_binop Ty_none And a b
+      | "bvor", [ a; b ] -> Expr.raw_binop Ty_none Or a b
+      | "bvxor", [ a; b ] -> Expr.raw_binop Ty_none Xor a b
+      | "bvadd", [ a; b ] -> Expr.raw_binop Ty_none Add a b
+      | "bvsub", [ a; b ] -> Expr.raw_binop Ty_none Sub a b
+      | "bvmul", [ a; b ] -> Expr.raw_binop Ty_none Mul a b
+      | "bvudiv", [ a; b ] -> Expr.raw_binop Ty_none DivU a b
+      | "bvurem", [ a; b ] -> Expr.raw_binop Ty_none RemU a b
+      | "bvshl", [ a; b ] -> Expr.raw_binop Ty_none Shl a b
+      | "bvlshr", [ a; b ] -> Expr.raw_binop Ty_none ShrL a b
+      | "bvashr", [ a; b ] -> Expr.raw_binop Ty_none ShrA a b
+      | "bvslt", [ a; b ] -> Expr.raw_relop Ty_none Lt a b
+      | "bvult", [ a; b ] -> Expr.raw_relop Ty_none LtU a b
+      | "bvsle", [ a; b ] -> Expr.raw_relop Ty_none Le a b
+      | "bvule", [ a; b ] -> Expr.raw_relop Ty_none LeU a b
+      | "bvsgt", [ a; b ] -> Expr.raw_relop Ty_none Gt a b
+      | "bvugt", [ a; b ] -> Expr.raw_relop Ty_none GtU a b
+      | "bvsge", [ a; b ] -> Expr.raw_relop Ty_none Ge a b
+      | "bvuge", [ a; b ] -> Expr.raw_relop Ty_none GeU a b
+      | "concat", [ a; b ] -> Expr.raw_concat a b
       | "fp", [ s; eb; i ] -> (
         match (Expr.view s, Expr.view eb, Expr.view i) with
         | Val (Str sign), Val (Str eb), Val (Str i) -> (
@@ -201,62 +201,62 @@ module Term = struct
         | _ ->
           Fmt.failwith "%acould not parse fp: %a %a %a" pp_loc loc Expr.pp s
             Expr.pp eb Expr.pp i )
-      | "fp.abs", [ a ] -> Expr.unop' Ty_none Abs a
-      | "fp.neg", [ a ] -> Expr.unop' Ty_none Neg a
+      | "fp.abs", [ a ] -> Expr.raw_unop Ty_none Abs a
+      | "fp.neg", [ a ] -> Expr.raw_unop Ty_none Neg a
       | ( "fp.add"
         , [ { node = Symbol { name = Simple "roundNearestTiesToEven"; _ }; _ }
           ; a
           ; b
           ] ) ->
-        Expr.binop' Ty_none Add a b
+        Expr.raw_binop Ty_none Add a b
       | ( "fp.sub"
         , [ { node = Symbol { name = Simple "roundNearestTiesToEven"; _ }; _ }
           ; a
           ; b
           ] ) ->
-        Expr.binop' Ty_none Sub a b
+        Expr.raw_binop Ty_none Sub a b
       | ( "fp.mul"
         , [ { node = Symbol { name = Simple "roundNearestTiesToEven"; _ }; _ }
           ; a
           ; b
           ] ) ->
-        Expr.binop' Ty_none Mul a b
+        Expr.raw_binop Ty_none Mul a b
       | ( "fp.div"
         , [ { node = Symbol { name = Simple "roundNearestTiesToEven"; _ }; _ }
           ; a
           ; b
           ] ) ->
-        Expr.binop' Ty_none Div a b
+        Expr.raw_binop Ty_none Div a b
       | ( "fp.sqrt"
         , [ { node = Symbol { name = Simple "roundNearestTiesToEven"; _ }; _ }
           ; a
           ] ) ->
-        Expr.unop' Ty_none Sqrt a
-      | "fp.rem", [ a; b ] -> Expr.binop' Ty_none Rem a b
+        Expr.raw_unop Ty_none Sqrt a
+      | "fp.rem", [ a; b ] -> Expr.raw_binop Ty_none Rem a b
       | ( "fp.roundToIntegral"
         , [ { node = Symbol { name = Simple "roundNearestTiesToEven"; _ }; _ }
           ; a
           ] ) ->
-        Expr.unop' Ty_none Nearest a
+        Expr.raw_unop Ty_none Nearest a
       | ( "fp.roundToIntegral"
         , [ { node = Symbol { name = Simple "roundTowardPositive"; _ }; _ }; a ]
         ) ->
-        Expr.unop' Ty_none Ceil a
+        Expr.raw_unop Ty_none Ceil a
       | ( "fp.roundToIntegral"
         , [ { node = Symbol { name = Simple "roundTowardNegative"; _ }; _ }; a ]
         ) ->
-        Expr.unop' Ty_none Floor a
+        Expr.raw_unop Ty_none Floor a
       | ( "fp.roundToIntegral"
         , [ { node = Symbol { name = Simple "roundTowardZero"; _ }; _ }; a ] )
         ->
-        Expr.unop' Ty_none Trunc a
-      | "fp.min", [ a; b ] -> Expr.binop' Ty_none Min a b
-      | "fp.max", [ a; b ] -> Expr.binop' Ty_none Max a b
-      | "fp.leq", [ a; b ] -> Expr.relop' Ty_bool Le a b
-      | "fp.lt", [ a; b ] -> Expr.relop' Ty_bool Lt a b
-      | "fp.geq", [ a; b ] -> Expr.relop' Ty_bool Ge a b
-      | "fp.gt", [ a; b ] -> Expr.relop' Ty_bool Gt a b
-      | "fp.eq", [ a; b ] -> Expr.relop' Ty_bool Eq a b
+        Expr.raw_unop Ty_none Trunc a
+      | "fp.min", [ a; b ] -> Expr.raw_binop Ty_none Min a b
+      | "fp.max", [ a; b ] -> Expr.raw_binop Ty_none Max a b
+      | "fp.leq", [ a; b ] -> Expr.raw_relop Ty_bool Le a b
+      | "fp.lt", [ a; b ] -> Expr.raw_relop Ty_bool Lt a b
+      | "fp.geq", [ a; b ] -> Expr.raw_relop Ty_bool Ge a b
+      | "fp.gt", [ a; b ] -> Expr.raw_relop Ty_bool Gt a b
+      | "fp.eq", [ a; b ] -> Expr.raw_relop Ty_bool Eq a b
       | _ -> Fmt.failwith "%acould not parse term app: %s" pp_loc loc name )
     | Symbol ({ name = Simple _; namespace = Attr; _ } as attr) ->
       Expr.app attr args
@@ -273,14 +273,14 @@ module Term = struct
           | None -> assert false
           | Some l -> l / 8
         in
-        Expr.extract' a ~high ~low
+        Expr.raw_extract a ~high ~low
       | "zero_extend", [ bits ], [ a ] ->
         let bits =
           match int_of_string_opt bits with
           | None -> assert false
           | Some bits -> bits
         in
-        Expr.cvtop' Ty_none (Zero_extend bits) a
+        Expr.raw_cvtop Ty_none (Zero_extend bits) a
       | "re.loop", [ i1; i2 ], [ a ] ->
         let i1 =
           match int_of_string_opt i1 with None -> assert false | Some i1 -> i1
@@ -288,7 +288,7 @@ module Term = struct
         let i2 =
           match int_of_string_opt i2 with None -> assert false | Some i2 -> i2
         in
-        Expr.unop' Ty_regexp (Regexp_loop (i1, i2)) a
+        Expr.raw_unop Ty_regexp (Regexp_loop (i1, i2)) a
       | _ ->
         Fmt.failwith "%acould not parse indexed app: %a" pp_loc loc Expr.pp id )
     | Symbol id ->

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -73,13 +73,13 @@ let test_unop_list () =
   let vlist = list [ Int 1; Int 2; Int 3 ] in
   let x = symbol "x" Ty_int in
   let y = symbol "y" Ty_int in
-  let slist = Expr.make (List [ x; y ]) in
+  let slist = Expr.list [ x; y ] in
   assert_equal (Expr.unop ty Head vlist) (int 1);
   assert_equal (Expr.unop ty Tail vlist) (list [ Int 2; Int 3 ]);
   assert_equal (Expr.unop ty Length vlist) (int 3);
   assert_equal (Expr.unop ty Reverse vlist) (list [ Int 3; Int 2; Int 1 ]);
   assert_equal (Expr.unop ty Head slist) x;
-  assert_equal (Expr.unop ty Tail slist) (Expr.make (List [ y ]));
+  assert_equal (Expr.unop ty Tail slist) (Expr.list [ y ]);
   assert_equal (Expr.unop ty Length slist) (int 2);
   assert_equal (Expr.unop ty Reverse (Expr.unop ty Reverse slist)) slist
 
@@ -171,12 +171,12 @@ let test_binop_list () =
   assert_equal
     (Expr.binop Ty_list List_append (list [ Int 0; Int 1 ]) (list [ Int 2 ]))
     clist;
-  let slist2 = Expr.make (List [ int 0; int 1 ]) in
-  let slist3 = Expr.make (List [ int 0; int 1; int 2 ]) in
+  let slist2 = Expr.list [ int 0; int 1 ] in
+  let slist3 = Expr.list [ int 0; int 1; int 2 ] in
   assert_equal (Expr.binop ty At slist3 (int 0)) (int 0);
   assert_equal (Expr.binop ty List_append slist2 (list [ Int 2 ])) slist3;
   assert_equal
-    (Expr.binop ty List_cons (int 0) (Expr.make (List [ int 1; int 2 ])))
+    (Expr.binop ty List_cons (int 0) (Expr.list [ int 1; int 2 ]))
     slist3
 
 let test_binop_i32 () =

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -541,22 +541,22 @@ let test_simplify_assoc () =
   let open Infix in
   let ty = Ty.Ty_int in
   let x = symbol "x" ty in
-  let binary = Expr.binop' Ty_int Add x (int 10) in
-  let sym = Expr.binop' Ty_int Add binary (int 3) in
-  assert_equal (Expr.simplify sym) (Expr.binop' Ty_int Add x (int 13));
-  let binary = Expr.binop' Ty_int Add x (int 10) in
-  let sym = Expr.binop' Ty_int Add (int 3) binary in
-  assert_equal (Expr.simplify sym) (Expr.binop' Ty_int Add (int 13) x)
+  let binary = Expr.raw_binop Ty_int Add x (int 10) in
+  let sym = Expr.raw_binop Ty_int Add binary (int 3) in
+  assert_equal (Expr.simplify sym) (Expr.raw_binop Ty_int Add x (int 13));
+  let binary = Expr.raw_binop Ty_int Add x (int 10) in
+  let sym = Expr.raw_binop Ty_int Add (int 3) binary in
+  assert_equal (Expr.simplify sym) (Expr.raw_binop Ty_int Add (int 13) x)
 
 let test_simplify_concat () =
   (* Test Concat of Extracts simplifications *)
   let open Infix in
   let x = symbol "x" (Ty_bitv 32) in
-  let b0 = Expr.extract' x ~high:1 ~low:0 in
-  let b1 = Expr.extract' x ~high:2 ~low:1 in
-  let b2 = Expr.extract' x ~high:3 ~low:2 in
-  let b3 = Expr.extract' x ~high:4 ~low:3 in
-  let b3210 = Expr.concat' b3 (Expr.concat' b2 (Expr.concat' b1 b0)) in
+  let b0 = Expr.raw_extract x ~high:1 ~low:0 in
+  let b1 = Expr.raw_extract x ~high:2 ~low:1 in
+  let b2 = Expr.raw_extract x ~high:3 ~low:2 in
+  let b3 = Expr.raw_extract x ~high:4 ~low:3 in
+  let b3210 = Expr.raw_concat b3 (Expr.raw_concat b2 (Expr.raw_concat b1 b0)) in
   assert_equal x (Expr.simplify b3210)
 
 let test_simplify () =


### PR DESCRIPTION
cc @zapashcanon 

I think this is harder then I thought, just including `expr.ml` and making `type expr = private` is not enough, now the solver needs to be parametric on an expression module so that it can take both `Safe_expr` and `Expr`.

Any ideas that wouldn't lead to code duplication? 