### PR TITLE
Use mappings.ml for Colibri2

### DIFF
--- a/smtml.opam
+++ b/smtml.opam
@@ -71,8 +71,8 @@ build: [
 dev-repo: "git+https://github.com/formalsec/smtml.git"
 available: arch != "arm32" & arch != "x86_32"
 pin-depends: [
-  ["colibri2.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#7d89a09b53ba9c649d80321950a42f536e416d62"]
-  ["colibrilib.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#7d89a09b53ba9c649d80321950a42f536e416d62"]
+  ["colibri2.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#5514303635152b2a0e74bc62914bd3fbcce55445"]
+  ["colibrilib.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#5514303635152b2a0e74bc62914bd3fbcce55445"]
   ["benchpress.dev" "git+https://github.com/sneeuwballen/benchpress.git#7f44cdd9f0511afcce2c9ad3c04cc9b72919bcff"]
   ["extunix.0.4.3" "git+https://github.com/filipeom/extunix.git#ff54e8cc7ec9cdc7171861d74d85f326dbcec62e"]
 ]

--- a/smtml.opam.template
+++ b/smtml.opam.template
@@ -1,7 +1,7 @@
 available: arch != "arm32" & arch != "x86_32"
 pin-depends: [
-  ["colibri2.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#7d89a09b53ba9c649d80321950a42f536e416d62"]
-  ["colibrilib.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#7d89a09b53ba9c649d80321950a42f536e416d62"]
+  ["colibri2.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#5514303635152b2a0e74bc62914bd3fbcce55445"]
+  ["colibrilib.0.4.0" "git+https://git.frama-c.com/pub/colibrics.git#5514303635152b2a0e74bc62914bd3fbcce55445"]
   ["benchpress.dev" "git+https://github.com/sneeuwballen/benchpress.git#7f44cdd9f0511afcce2c9ad3c04cc9b72919bcff"]
   ["extunix.0.4.3" "git+https://github.com/filipeom/extunix.git#ff54e8cc7ec9cdc7171861d74d85f326dbcec62e"]
 ]

--- a/src/smtml/dolmenexpr_to_expr.ml
+++ b/src/smtml/dolmenexpr_to_expr.ml
@@ -72,6 +72,276 @@ module Builtin = struct
       (DTy.arrow [ string_ty ] float64_ty)
 end
 
+module DolmenIntf = struct
+  include DTerm
+
+  type ty = DTy.t
+
+  type term = DTerm.t
+
+  type func_decl = DTerm.Const.t
+
+  let caches_consts = true
+
+  let true_ = DTerm._true
+
+  let false_ = DTerm._false
+
+  let int i = DTerm.Int.mk (string_of_int i)
+
+  let real r = DTerm.Real.mk (string_of_float r)
+
+  let const s ty = DTerm.of_cst (DTerm.Const.mk (Dolmen_std.Path.global s) ty)
+
+  let not_ = DTerm.neg
+
+  let and_ a b = DTerm._and [ a; b ]
+
+  let or_ a b = DTerm._or [ a; b ]
+
+  let logand = DTerm._and
+
+  let logor = DTerm._or
+
+  let get_vars_from_terms tl =
+    List.map
+      (fun (t : DTerm.t) ->
+        match t.term_descr with
+        | Var v -> v
+        | _ ->
+          Fmt.failwith {|Can't quantify non-variable term "%a"|} DTerm.print t )
+      tl
+
+  let forall tl t =
+    let tvl = get_vars_from_terms tl in
+    DTerm.all ([], tvl) t
+
+  let exists (tl : term list) t =
+    let tvl = get_vars_from_terms tl in
+    DTerm.ex ([], tvl) t
+
+  let nary_to_binary f tl =
+    let rec aux acc = function
+      | [] -> acc
+      | h :: t -> aux (DTerm.apply_cst f [] [ acc; h ]) t
+    in
+    match tl with
+    | h1 :: h2 :: t -> aux (DTerm.apply_cst f [] [ h1; h2 ]) t
+    | _ ->
+      Fmt.failwith {|%a applied to less than two terms|} DTerm.Const.print f
+
+  let int_of_term (t : DTerm.t) =
+    match t.term_descr with
+    | Cst { builtin = DBuiltin.Integer i; _ } ->
+      (* There may be a proper alternative to int_of_string somewhere,
+         since its hidden by prelude. *)
+      Z.to_int (Z.of_string i)
+    | _ ->
+      Fmt.failwith
+        {|int_of_term: expected a term that is an integer constant, instead got: %a|}
+        DTerm.print t
+
+  module Types = struct
+    include DTy
+
+    let ty = DTerm.ty
+
+    let to_ety (ty : DTy.t) : Ty.t =
+      match ty with
+      | { ty_descr = TyApp ({ builtin = DBuiltin.Int; _ }, _); _ } -> Ty_int
+      | { ty_descr = TyApp ({ builtin = DBuiltin.Real; _ }, _); _ } -> Ty_real
+      | { ty_descr = TyApp ({ builtin = DBuiltin.Prop; _ }, _); _ } -> Ty_bool
+      | { ty_descr =
+            TyApp
+              ( { builtin = DBuiltin.Base
+                ; path = Absolute { name = "StringTy"; _ }
+                ; _
+                }
+              , _ )
+        ; _
+        } ->
+        Ty_str
+      | { ty_descr = TyApp ({ builtin = DBuiltin.Bitv n; _ }, _); _ } ->
+        Ty_bitv n
+      | { ty_descr = TyApp ({ builtin = DBuiltin.Float (8, 24); _ }, _); _ } ->
+        Ty_fp 32
+      | { ty_descr = TyApp ({ builtin = DBuiltin.Float (11, 53); _ }, _); _ } ->
+        Ty_fp 64
+      | _ -> Fmt.failwith {|Unsupported dolmen type "%a"|} DTy.print ty
+  end
+
+  module Int = struct
+    include DTerm.Int
+
+    let neg = DTerm.Int.minus
+  end
+
+  module Real = struct
+    include DTerm.Real
+
+    let neg = DTerm.Real.minus
+  end
+
+  module String = struct
+    include DTerm.String
+
+    let v = DTerm.String.of_ustring
+
+    let to_re = DTerm.String.RegLan.of_string
+
+    let at t ~pos = DTerm.String.at t pos
+
+    let concat = nary_to_binary DTerm.Const.String.concat
+
+    let contains t ~sub = DTerm.String.contains t sub
+
+    let is_prefix t ~prefix = DTerm.String.is_prefix t prefix
+
+    let is_suffix t ~suffix = DTerm.String.is_suffix t suffix
+
+    let le = DTerm.String.leq
+
+    let sub t ~pos ~len = DTerm.String.sub t pos len
+
+    let index_of t ~sub ~pos = DTerm.String.index_of t sub pos
+
+    let replace t ~pattern ~with_ = DTerm.String.replace t pattern with_
+  end
+
+  module Re = struct
+    let star = DTerm.String.RegLan.star
+
+    let plus = DTerm.String.RegLan.cross
+
+    let opt = DTerm.String.RegLan.option
+
+    let comp = DTerm.String.RegLan.complement
+
+    let range = DTerm.String.RegLan.range
+
+    let loop t i1 i2 = DTerm.String.RegLan.loop i1 i2 t
+
+    let union = nary_to_binary DTerm.Const.String.Reg_Lang.union
+
+    let concat = nary_to_binary DTerm.Const.String.Reg_Lang.concat
+  end
+
+  module Bitv = struct
+    include DTerm.Bitv
+
+    let v bv n =
+      let bv = Z.format (Fmt.str "%c0%db" '%' n) (Z.of_string bv) in
+      DTerm.Bitv.mk bv
+
+    let lognot = DTerm.Bitv.not
+
+    let div = DTerm.Bitv.sdiv
+
+    let div_u = DTerm.Bitv.udiv
+
+    let logor = DTerm.Bitv.or_
+
+    let logand = DTerm.Bitv.and_
+
+    let logxor = DTerm.Bitv.xor
+
+    let shl = DTerm.Bitv.shl
+
+    let ashr = DTerm.Bitv.ashr
+
+    let lshr = DTerm.Bitv.lshr
+
+    let rem = DTerm.Bitv.srem
+
+    let rem_u = DTerm.Bitv.urem
+
+    let rotate_left t1 t2 = DTerm.Bitv.rotate_left (int_of_term t1) t2
+
+    let rotate_right t1 t2 = DTerm.Bitv.rotate_right (int_of_term t1) t2
+
+    let lt t1 t2 = DTerm.Bitv.slt t1 t2
+
+    let lt_u t1 t2 = DTerm.Bitv.ult t1 t2
+
+    let le = DTerm.Bitv.sle
+
+    let le_u = DTerm.Bitv.ule
+
+    let gt t1 t2 = DTerm.Bitv.sgt t1 t2
+
+    let gt_u t1 t2 = DTerm.Bitv.ugt t1 t2
+
+    let ge = DTerm.Bitv.sge
+
+    let ge_u = DTerm.Bitv.uge
+
+    let extract t ~high ~low = DTerm.Bitv.extract high low t
+  end
+
+  module Float = struct
+    include DTerm.Float
+
+    module Rounding_mode = struct
+      let rne = DTerm.Float.roundNearestTiesToEven
+
+      let rna = DTerm.Float.roundNearestTiesToAway
+
+      let rtp = DTerm.Float.roundTowardPositive
+
+      let rtn = DTerm.Float.roundTowardNegative
+
+      let rtz = DTerm.Float.roundTowardZero
+    end
+
+    let v f e s =
+      DTerm.Float.real_to_fp e s DTerm.Float.roundTowardZero
+        (DTerm.Real.mk (Prelude.Float.to_string f))
+
+    let sqrt ~rm t = DTerm.Float.sqrt rm t
+
+    let is_nan = DTerm.Float.isNaN
+
+    let round_to_integral ~rm t = DTerm.Float.roundToIntegral rm t
+
+    let add ~rm t1 t2 = DTerm.Float.add rm t1 t2
+
+    let sub ~rm t1 t2 = DTerm.Float.sub rm t1 t2
+
+    let mul ~rm t1 t2 = DTerm.Float.mul rm t1 t2
+
+    let div ~rm t1 t2 = DTerm.Float.div rm t1 t2
+
+    let le = DTerm.Float.leq
+
+    let ge = DTerm.Float.geq
+
+    let to_fp e s ~rm fp = DTerm.Float.to_fp e s rm fp
+
+    let sbv_to_fp e s ~rm bv = DTerm.Float.sbv_to_fp e s rm bv
+
+    let ubv_to_fp e s ~rm bv = DTerm.Float.ubv_to_fp e s rm bv
+
+    let to_ubv n ~rm fp = DTerm.Float.to_ubv n rm fp
+
+    let to_sbv n ~rm fp = DTerm.Float.to_sbv n rm fp
+
+    let of_ieee_bv _eb _sb _bv = assert false
+
+    let to_ieee_bv _fp = assert false
+  end
+
+  module Func = struct
+    let make name tyl ty =
+      DTerm.Const.mk (Dolmen_std.Path.global name) (DTy.arrow tyl ty)
+
+    let apply f tl = DTerm.apply_cst f [] tl
+  end
+
+  module Smtlib = struct
+    let pp ?name:_ ?logic:_ ?status:_ = Fmt.list DTerm.print
+  end
+end
+
 let tty_of_etype (e : Ty.t) : DTy.t =
   match e with
   | Ty_int -> DTy.int

--- a/src/smtml/dolmenexpr_to_expr.ml
+++ b/src/smtml/dolmenexpr_to_expr.ml
@@ -81,7 +81,7 @@ module DolmenIntf = struct
 
   type func_decl = DTerm.Const.t
 
-  let caches_consts = true
+  let caches_consts = false
 
   let true_ = DTerm._true
 

--- a/src/smtml/dolmenexpr_to_expr.mli
+++ b/src/smtml/dolmenexpr_to_expr.mli
@@ -3,6 +3,7 @@
 (* Written by Hichem Rami Ait El Hara *)
 
 module DExpr = Dolmen_std.Expr
+module DTy = DExpr.Ty
 module DTerm = DExpr.Term
 
 module Builtin : sig
@@ -33,6 +34,312 @@ module Builtin : sig
   val f64_to_string : DExpr.term_cst
 
   val string_to_f64 : DExpr.term_cst
+end
+
+module DolmenIntf : sig
+  type ty = DTy.t
+
+  type term = DTerm.t
+
+  type func_decl = DTerm.Const.t
+
+  val caches_consts : bool
+
+  val true_ : term
+
+  val false_ : term
+
+  val int : int -> term
+
+  val real : float -> term
+
+  val const : string -> ty -> term
+
+  val not_ : term -> term
+
+  val and_ : term -> term -> term
+
+  val or_ : term -> term -> term
+
+  val logand : term list -> term
+
+  val logor : term list -> term
+
+  val xor : term -> term -> term
+
+  val eq : term -> term -> term
+
+  val distinct : term list -> term
+
+  val ite : term -> term -> term -> term
+
+  val forall : term list -> term -> term
+
+  val exists : term list -> term -> term
+
+  module Types : sig
+    val int : ty
+
+    val real : ty
+
+    val bool : ty
+
+    val string : ty
+
+    val bitv : int -> ty
+
+    val float : int -> int -> ty
+
+    val ty : term -> ty
+
+    val to_ety : ty -> Ty.t
+  end
+
+  module Int : sig
+    val neg : term -> term
+
+    val to_real : term -> term
+
+    val add : term -> term -> term
+
+    val sub : term -> term -> term
+
+    val mul : term -> term -> term
+
+    val div : term -> term -> term
+
+    val rem : term -> term -> term
+
+    val pow : term -> term -> term
+
+    val lt : term -> term -> term
+
+    val le : term -> term -> term
+
+    val gt : term -> term -> term
+
+    val ge : term -> term -> term
+  end
+
+  module Real : sig
+    val neg : term -> term
+
+    val to_int : term -> term
+
+    val add : term -> term -> term
+
+    val sub : term -> term -> term
+
+    val mul : term -> term -> term
+
+    val div : term -> term -> term
+
+    val pow : term -> term -> term
+
+    val lt : term -> term -> term
+
+    val le : term -> term -> term
+
+    val gt : term -> term -> term
+
+    val ge : term -> term -> term
+  end
+
+  module String : sig
+    val v : string -> term
+
+    val length : term -> term
+
+    val to_code : term -> term
+
+    val of_code : term -> term
+
+    val to_int : term -> term
+
+    val of_int : term -> term
+
+    val to_re : term -> term
+
+    val at : term -> pos:term -> term
+
+    val concat : term list -> term
+
+    val contains : term -> sub:term -> term
+
+    val is_prefix : term -> prefix:term -> term
+
+    val is_suffix : term -> suffix:term -> term
+
+    val in_re : term -> term -> term
+
+    val lt : term -> term -> term
+
+    val le : term -> term -> term
+
+    val sub : term -> pos:term -> len:term -> term
+
+    val index_of : term -> sub:term -> pos:term -> term
+
+    val replace : term -> pattern:term -> with_:term -> term
+  end
+
+  module Re : sig
+    val star : term -> term
+
+    val plus : term -> term
+
+    val opt : term -> term
+
+    val comp : term -> term
+
+    val range : term -> term -> term
+
+    val loop : term -> int -> int -> term
+
+    val union : term list -> term
+
+    val concat : term list -> term
+  end
+
+  module Bitv : sig
+    val v : string -> int -> term
+
+    val neg : term -> term
+
+    val lognot : term -> term
+
+    val add : term -> term -> term
+
+    val sub : term -> term -> term
+
+    val mul : term -> term -> term
+
+    val div : term -> term -> term
+
+    val div_u : term -> term -> term
+
+    val logor : term -> term -> term
+
+    val logand : term -> term -> term
+
+    val logxor : term -> term -> term
+
+    val shl : term -> term -> term
+
+    val ashr : term -> term -> term
+
+    val lshr : term -> term -> term
+
+    val rem : term -> term -> term
+
+    val rem_u : term -> term -> term
+
+    val rotate_left : term -> term -> term
+
+    val rotate_right : term -> term -> term
+
+    val lt : term -> term -> term
+
+    val lt_u : term -> term -> term
+
+    val le : term -> term -> term
+
+    val le_u : term -> term -> term
+
+    val gt : term -> term -> term
+
+    val gt_u : term -> term -> term
+
+    val ge : term -> term -> term
+
+    val ge_u : term -> term -> term
+
+    val concat : term -> term -> term
+
+    val extract : term -> high:int -> low:int -> term
+
+    val zero_extend : int -> term -> term
+
+    val sign_extend : int -> term -> term
+  end
+
+  module Float : sig
+    module Rounding_mode : sig
+      val rne : term
+
+      val rna : term
+
+      val rtp : term
+
+      val rtn : term
+
+      val rtz : term
+    end
+
+    val v : float -> int -> int -> term
+
+    val neg : term -> term
+
+    val abs : term -> term
+
+    val sqrt : rm:term -> term -> term
+
+    val is_nan : term -> term
+
+    val round_to_integral : rm:term -> term -> term
+
+    val add : rm:term -> term -> term -> term
+
+    val sub : rm:term -> term -> term -> term
+
+    val mul : rm:term -> term -> term -> term
+
+    val div : rm:term -> term -> term -> term
+
+    val min : term -> term -> term
+
+    val max : term -> term -> term
+
+    val rem : term -> term -> term
+
+    val eq : term -> term -> term
+
+    val lt : term -> term -> term
+
+    val le : term -> term -> term
+
+    val gt : term -> term -> term
+
+    val ge : term -> term -> term
+
+    val to_fp : int -> int -> rm:term -> term -> term
+
+    val sbv_to_fp : int -> int -> rm:term -> term -> term
+
+    val ubv_to_fp : int -> int -> rm:term -> term -> term
+
+    val to_ubv : int -> rm:term -> term -> term
+
+    val to_sbv : int -> rm:term -> term -> term
+
+    val of_ieee_bv : int -> int -> term -> term
+
+    val to_ieee_bv : term -> term
+  end
+
+  module Func : sig
+    val make : string -> ty list -> ty -> func_decl
+
+    val apply : func_decl -> term list -> term
+  end
+
+  module Smtlib : sig
+    val pp :
+         ?name:string
+      -> ?logic:Logic.t
+      -> ?status:[ `Sat | `Unknown | `Unsat ]
+      -> term list Fmt.t
+  end
 end
 
 val tty_of_etype : Ty.t -> DTerm.ty

--- a/src/smtml/mappings.ml
+++ b/src/smtml/mappings.ml
@@ -66,7 +66,7 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
 
     let make_symbol (ctx : symbol_ctx) (s : Symbol.t) : symbol_ctx * M.term =
       let name = match s.name with Simple name -> name | _ -> assert false in
-      if not M.caches_consts then
+      if M.caches_consts then
         let sym = M.const name (get_type s.ty) in
         (Smap.add s sym ctx, sym)
       else

--- a/src/smtml/mappings.ml
+++ b/src/smtml/mappings.ml
@@ -66,7 +66,7 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
 
     let make_symbol (ctx : symbol_ctx) (s : Symbol.t) : symbol_ctx * M.term =
       let name = match s.name with Simple name -> name | _ -> assert false in
-      if M.caches_consts then
+      if not M.caches_consts then
         let sym = M.const name (get_type s.ty) in
         (Smap.add s sym ctx, sym)
       else

--- a/src/smtml/params.ml
+++ b/src/smtml/params.ml
@@ -9,6 +9,7 @@ type _ param =
   | Ematching : bool param
   | Parallel : bool param
   | Num_threads : int param
+  | Debug : bool param
 
 let discr : type a. a param -> int = function
   | Timeout -> 0
@@ -17,6 +18,7 @@ let discr : type a. a param -> int = function
   | Ematching -> 3
   | Parallel -> 4
   | Num_threads -> 5
+  | Debug -> 6
 
 module Key = struct
   type t = K : 'a param -> t
@@ -46,6 +48,8 @@ let default_parallel = false
 
 let default_num_threads = 1
 
+let default_debug = false
+
 let default_value (type a) (param : a param) : a =
   match param with
   | Timeout -> default_timeout
@@ -54,6 +58,7 @@ let default_value (type a) (param : a param) : a =
   | Ematching -> default_ematching
   | Parallel -> default_parallel
   | Num_threads -> default_num_threads
+  | Debug -> default_debug
 
 let default () =
   Pmap.empty
@@ -80,7 +85,9 @@ let get (type a) (params : t) (param : a param) : a =
   | Ematching, Some (P (Ematching, v)) -> v
   | Parallel, Some (P (Parallel, v)) -> v
   | Num_threads, Some (P (Num_threads, v)) -> v
-  | (Timeout | Model | Unsat_core | Ematching | Parallel | Num_threads), _ ->
+  | Debug, Some (P (Debug, v)) -> v
+  | ( (Timeout | Model | Unsat_core | Ematching | Parallel | Num_threads | Debug)
+    , _ ) ->
     assert false
 
 let to_list params = List.map snd @@ Pmap.bindings params

--- a/src/smtml/params.mli
+++ b/src/smtml/params.mli
@@ -23,6 +23,7 @@ type _ param =
   | Parallel : bool param  (** Enable or disable parallel execution. *)
   | Num_threads : int param
     (** Specifies the maximum number of threads to use in parallel mode. *)
+  | Debug : bool param  (** Enable or disable solver debugging messages. *)
 
 (** The type [param'] is a wrapper for storing parameter-value pairs. *)
 type param' = P : 'a param * 'a -> param'

--- a/src/smtml/z3_mappings.default.ml
+++ b/src/smtml/z3_mappings.default.ml
@@ -442,6 +442,7 @@ module M = struct
       | Parallel -> Z3.set_global_param "parallel.enable" (string_of_bool v)
       | Num_threads ->
         Z3.set_global_param "parallel.threads.max" (string_of_int v)
+      | Debug -> ()
 
     let set_params (params : Params.t) =
       List.iter (fun (Params.P (p, v)) -> set_param p v) (Params.to_list params)

--- a/test/solver/test_solver.ml
+++ b/test/solver/test_solver.ml
@@ -15,7 +15,8 @@ module Make (M : Mappings_intf.S) = struct
     let params =
       Params.(
         default () $ (Timeout, 900) $ (Model, false) $ (Unsat_core, true)
-        $ (Ematching, false) $ (Parallel, true) $ (Num_threads, 1) )
+        $ (Ematching, false) $ (Parallel, true) $ (Num_threads, 1)
+        $ (Debug, false) )
     in
     assert (Params.get params Unsat_core);
     let _ : Solver.t = Solver.create ~params () in


### PR DESCRIPTION
I made this change so that I don't have to copy definitions of unsupported symbols.
I will do the same with Alt-Ergo once #326 is merged