### PR TITLE
Normalize expressions for better term hash-consing and cache/constraint independance

### DIFF
--- a/src/smtml/expr.ml
+++ b/src/smtml/expr.ml
@@ -328,6 +328,7 @@ let unop ty op hte =
   | _, Val v -> value (Eval.unop ty op v)
   | Not, Unop (_, Not, hte') -> hte'
   | Not, Relop (t, Eq, a,b) -> make (Relop (t, Ne, a, b))
+  | Not, Relop (t, Ne, a,b) -> make (Relop (t, Eq, a, b))
   | Neg, Unop (_, Neg, hte') -> hte'
   | Trim, Cvtop (Ty_real, ToString, _) -> hte
   | Head, List (hd :: _) -> hd
@@ -425,8 +426,6 @@ let rec relop ty op hte1 hte2 =
     if Int32.equal b1 b2 then relop Ty_bool Eq os1 os2 else value False
   | Ne, Ptr { base = b1; offset = os1 }, Ptr { base = b2; offset = os2 } ->
     if Int32.equal b1 b2 then relop Ty_bool Ne os1 os2 else value True
-  | GtU, _, _ -> relop ty LtU hte2 hte1
-  | GeU, _, _ -> relop ty LeU hte2 hte1
   | ( (LtU | LeU)
     , Ptr { base = b1; offset = os1 }
     , Ptr { base = b2; offset = os2 } ) ->
@@ -443,6 +442,10 @@ let rec relop ty op hte1 hte2 =
     let base = Eval.binop (Ty_bitv 32) Add (Num (I32 base)) o in
     value (if Eval.relop ty op base n then True else False)
   | op, List l1, List l2 -> relop_list op l1 l2
+  | Gt, _, _ -> relop ty Lt hte2 hte1
+  | GtU, _, _ -> relop ty LtU hte2 hte1
+  | Ge, _, _ -> relop ty Le hte2 hte1
+  | GeU, _, _ -> relop ty LeU hte2 hte1
   | _, _, _ -> raw_relop ty op hte1 hte2
 
 and relop_list op l1 l2 =


### PR DESCRIPTION
This PR adds basic normalization rules in Expr to improve term equivalence and hash-consing:

- not (a = b) → (a ≠ b)
- a > b → b < a
- a ≥ b → b ≤ a

These are handled directly in Expr.unop and Expr.relop.
Let me know if this is the right place for them or if you'd prefer these moved to a separate normalization step.

