### PR TITLE
Support uninterpreted applications in the solver

### DIFF
--- a/src/smtml/ast.ml
+++ b/src/smtml/ast.ml
@@ -9,6 +9,11 @@ type t =
       { id : Symbol.t
       ; sort : Symbol.t
       }
+  | Declare_fun of
+      { id : Symbol.t
+      ; args : Symbol.t list
+      ; sort : Symbol.t
+      }
   | Echo of string
   | Exit
   | Get_assertions
@@ -37,6 +42,10 @@ let pp fmt (instr : t) =
       assumptuions
   | Declare_const { id; sort } ->
     Fmt.pf fmt "(declare-const %a %a)" Symbol.pp id Symbol.pp sort
+  | Declare_fun { id; args; sort } ->
+    Fmt.pf fmt "(declare-fun %a (%a) %a)" Symbol.pp id
+      (Fmt.list ~sep:Fmt.sp Symbol.pp)
+      args Symbol.pp sort
   | Echo line -> Fmt.pf fmt "(echo %S)" line
   | Exit -> Fmt.string fmt "(exit)"
   | Get_assertions -> Fmt.string fmt "(get-assertions)"

--- a/src/smtml/ast.mli
+++ b/src/smtml/ast.mli
@@ -23,6 +23,13 @@ type t =
       }
     (** [Declare_const { id; sort }] declares a new constant [id] of type
         [sort]. *)
+  | Declare_fun of
+      { id : Symbol.t  (** The identifier of the constant. *)
+      ; args : Symbol.t list  (** The sorts (types) of the arguments. *)
+      ; sort : Symbol.t  (** The sort (type) of the declared function. *)
+      }
+    (** [Declare_fun { id; args; sort }] declares a new constant [id] of type
+        [args -> sort]. *)
   | Echo of string
     (** [Echo msg] prints the given message [msg] to the standard output. *)
   | Exit  (** [Exit] terminates the SMT solver session. *)

--- a/src/smtml/interpret.ml
+++ b/src/smtml/interpret.ml
@@ -32,6 +32,7 @@ module Make (Solver : Solver_intf.S) = struct
       | `Unknown -> Fmt.pr "unknown@." );
       state
     | Declare_const _x -> state
+    | Declare_fun _x -> state
     | Echo x ->
       Fmt.pr "%a" Fmt.string x;
       state

--- a/test/cli/smt2/dune
+++ b/test/cli/smt2/dune
@@ -17,4 +17,5 @@
   test_lra.smt2
   test_string_all.smt2
   test_string_hard.smt2
-  test_implication.smt2))
+  test_implication.smt2
+  test_uninterpreted.smt2))

--- a/test/cli/smt2/test_smt2.t
+++ b/test/cli/smt2/test_smt2.t
@@ -92,3 +92,9 @@ Test Forall and Exists parsing:
 Test implication:
   $ smtml run test_implication.smt2
   sat
+
+Test uninterpreted:
+  $ smtml run test_uninterpreted.smt2
+  sat
+  (model
+    (x f32 0.))

--- a/test/cli/smt2/test_uninterpreted.smt2
+++ b/test/cli/smt2/test_uninterpreted.smt2
@@ -1,0 +1,5 @@
+(declare-fun f ((_ FloatingPoint 8 24)) (_ BitVec 32))
+(declare-const x (_ FloatingPoint 8 24))
+(assert (= (f x) #x0000002a))
+(check-sat)
+(get-model)


### PR DESCRIPTION
Support unknown function applications as uninterpreted functions in the solver.

cc @georgiy-belyanin 

This should now work on https://github.com/formalsec/smtml/pull/342#pullrequestreview-2832429947

This is still far from a perfect solution, but I think that it's good enough for now. Models don't fetch the assignments for the uninterpreted functions yet, but I plan do this next