### PR TITLE
Add solver mappings `Internals` module and generic `to_ieee_bv` impl

### DIFF
--- a/src/smtml/altergo_mappings.default.ml
+++ b/src/smtml/altergo_mappings.default.ml
@@ -318,6 +318,6 @@ module Fresh = struct
   end
 end
 
-let is_available = true
-
 include Fresh.Make ()
+
+let is_available = Internals.is_available

--- a/src/smtml/colibri2_mappings.default.ml
+++ b/src/smtml/colibri2_mappings.default.ml
@@ -299,9 +299,9 @@ module M = struct
     end
   end
 
-  let is_available = true
-
   include Make ()
+
+  let is_available = Internals.is_available
 end
 
 module M' : Mappings_intf.M_with_make = M

--- a/src/smtml/cvc5_mappings.default.ml
+++ b/src/smtml/cvc5_mappings.default.ml
@@ -6,6 +6,14 @@ open Cvc5
 include Mappings_intf
 
 module Fresh_cvc5 () = struct
+  module Internals = struct
+    let caches_consts = false
+
+    let is_available = true
+
+    let has_to_ieee_bv = false
+  end
+
   type ty = Sort.sort
 
   type term = Term.term
@@ -21,8 +29,6 @@ module Fresh_cvc5 () = struct
   type optimizer = unit (* Not supported *)
 
   type func_decl = unit
-
-  let caches_consts = false
 
   let tm = TermManager.mk_tm ()
 
@@ -518,10 +524,9 @@ end
 
 module Cvc5_with_make : Mappings_intf.M_with_make = struct
   module Make () = Fresh_cvc5 ()
-
-  let is_available = true
-
   include Fresh_cvc5 ()
+
+  let is_available = Internals.is_available
 end
 
 include Mappings.Make (Cvc5_with_make)

--- a/src/smtml/dolmenexpr_to_expr.ml
+++ b/src/smtml/dolmenexpr_to_expr.ml
@@ -75,13 +75,19 @@ end
 module DolmenIntf = struct
   include DTerm
 
+  module Internals = struct
+    let caches_consts = false
+
+    let is_available = true
+
+    let has_to_ieee_bv = false
+  end
+
   type ty = DTy.t
 
   type term = DTerm.t
 
   type func_decl = DTerm.Const.t
-
-  let caches_consts = false
 
   let true_ = DTerm._true
 

--- a/src/smtml/dolmenexpr_to_expr.mli
+++ b/src/smtml/dolmenexpr_to_expr.mli
@@ -37,13 +37,19 @@ module Builtin : sig
 end
 
 module DolmenIntf : sig
+  module Internals : sig
+    val caches_consts : bool
+
+    val is_available : bool
+
+    val has_to_ieee_bv : bool
+  end
+
   type ty = DTy.t
 
   type term = DTerm.t
 
   type func_decl = DTerm.Const.t
-
-  val caches_consts : bool
 
   val true_ : term
 

--- a/src/smtml/mappings.nop.ml
+++ b/src/smtml/mappings.nop.ml
@@ -4,6 +4,14 @@
 
 module Nop = struct
   module Make () = struct
+    module Internals = struct
+      let caches_consts = false
+
+      let is_available = false
+
+      let has_to_ieee_bv = false
+    end
+
     type ty = unit
 
     type term = unit
@@ -19,8 +27,6 @@ module Nop = struct
     type optimizer
 
     type func_decl = unit
-
-    let caches_consts = false
 
     let true_ = ()
 

--- a/src/smtml/mappings_intf.ml
+++ b/src/smtml/mappings_intf.ml
@@ -13,6 +13,18 @@
     solvers, including term construction, type handling, and solver interaction.
 *)
 module type M = sig
+  module Internals : sig
+    (** [is_available] indicates whether the module is available for use. *)
+    val is_available : bool
+
+    (** [caches_consts] indicates whether the solver caches constants. *)
+    val caches_consts : bool
+
+    (** [has_to_ieee_bv] indicates whether the solver native support for the
+        [to_ieee_bv]. *)
+    val has_to_ieee_bv : bool
+  end
+
   (** The type of SMT sorts (types). *)
   type ty
 
@@ -36,9 +48,6 @@ module type M = sig
 
   (** The type of function declarations. *)
   type func_decl
-
-  (** [caches_consts] indicates whether the solver caches constants. *)
-  val caches_consts : bool
 
   (** [true_] represents the Boolean constant [true]. *)
   val true_ : term
@@ -74,7 +83,8 @@ module type M = sig
   (** [xor t1 t2] constructs the logical XOR of the terms [t1] and [t2]. *)
   val xor : term -> term -> term
 
-  (** [implies t1 t2] constructs the logical implication of the terms [t1] and [t2]. *)
+  (** [implies t1 t2] constructs the logical implication of the terms [t1] and
+      [t2]. *)
   val implies : term -> term -> term
 
   (** [eq t1 t2] constructs the equality of the terms [t1] and [t2]. *)
@@ -711,7 +721,10 @@ module type M_with_make = sig
   (** [Make ()] creates a new instance of the [M] module type. *)
   module Make () : M
 
-  (** [is_available] indicates whether the module is available for use. *)
+  (** [is_available] indicates whether the module is available for use.
+
+      Will be deprecated in the future, please use Internals.is_available
+      instead. *)
   val is_available : bool
 
   (** Include the [M] module type. *)

--- a/src/smtml/z3_mappings.default.ml
+++ b/src/smtml/z3_mappings.default.ml
@@ -6,6 +6,14 @@ include Mappings_intf
 
 module M = struct
   module Make () = struct
+    module Internals = struct
+      let caches_consts = true
+
+      let is_available = true
+
+      let has_to_ieee_bv = true
+    end
+
     type ty = Z3.Sort.sort
 
     type term = Z3.Expr.expr
@@ -21,8 +29,6 @@ module M = struct
     type optimizer = Z3.Optimize.optimize
 
     type func_decl = Z3.FuncDecl.func_decl
-
-    let caches_consts = true
 
     let ctx = Z3.mk_context []
 
@@ -554,9 +560,9 @@ module M = struct
     end
   end
 
-  let is_available = true
-
   include Make ()
+
+  let is_available = Internals.is_available
 end
 
 module M' : Mappings_intf.M_with_make = M


### PR DESCRIPTION
- All the mappings now include a `Internals` module that will inform the `Mappings` module of internal behaviours, such as const caching and native support for the `to_ieee_bv` operator.

- Lift `to_ieee_bv` implementation to the `Mappings` module so that other solvers that don't have native support for `to_ieee_bv` use this aproximated implementation.

This propagates #345 to Colibri2 and Alt-Ergo 