### PR TITLE
Fix `rotate_{left|right}` order of arguments in dolmenexpr_to_expr

### DIFF
--- a/src/smtml/dolmenexpr_to_expr.ml
+++ b/src/smtml/dolmenexpr_to_expr.ml
@@ -269,9 +269,9 @@ module DolmenIntf = struct
 
     let rem_u = DTerm.Bitv.urem
 
-    let rotate_left t1 t2 = DTerm.Bitv.rotate_left (int_of_term t1) t2
+    let rotate_left t1 t2 = DTerm.Bitv.rotate_left (int_of_term t2) t1
 
-    let rotate_right t1 t2 = DTerm.Bitv.rotate_right (int_of_term t1) t2
+    let rotate_right t1 t2 = DTerm.Bitv.rotate_right (int_of_term t2) t1
 
     let lt t1 t2 = DTerm.Bitv.slt t1 t2
 


### PR DESCRIPTION
Should fix https://github.com/OCamlPro/owi/issues/637#issuecomment-2889089206 at least in the case where the number of bits to rotate is concrete.