### PR TITLE
Log SMT queries per test

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -84,6 +84,8 @@
   rusage
   (scfg
    (>= "0.5"))
+  (mtime
+    (>= "2.0.0"))
   (yojson
    (>= "1.6.0"))
   (zarith

--- a/smtml.opam
+++ b/smtml.opam
@@ -34,6 +34,7 @@ depends: [
   "prelude" {>= "0.5"}
   "rusage"
   "scfg" {>= "0.5"}
+  "mtime" {>= "2.0.0"}
   "yojson" {>= "1.6.0"}
   "zarith" {>= "1.5"}
   "odoc" {with-doc}

--- a/src/smtml/binder.ml
+++ b/src/smtml/binder.ml
@@ -3,6 +3,7 @@ type t =
   | Forall
   | Exists
   | Let_in
+[@@deriving ord]
 
 let equal a b =
   match (a, b) with

--- a/src/smtml/binder.mli
+++ b/src/smtml/binder.mli
@@ -15,6 +15,7 @@ type t =
   | Exists  (** Existential quantifier ([exists x. P(x)]). *)
   | Let_in
     (** Let-binding ([let x = e in P(x)]), used for local definitions. *)
+[@@deriving ord]
 
 (** [equal q1 q2] returns [true] if the quantifiers or binding constructs [q1]
     and [q2] are equal. *)

--- a/src/smtml/dune
+++ b/src/smtml/dune
@@ -70,6 +70,7 @@
   scfg
   smtml.prelude
   yojson
+  mtime.clock
   zarith
   (select
    colibri2_mappings.ml
@@ -106,7 +107,9 @@
    (-> altergo_mappings.nop.ml)))
  (instrumentation
   (backend bisect_ppx --exclusions src/smtml/bisect.exclude)
-  (deps bisect.exclude)))
+  (deps bisect.exclude))
+ (preprocess
+  (pps ppx_deriving.std)))
 
 (rule
  (targets

--- a/src/smtml/ty.ml
+++ b/src/smtml/ty.ml
@@ -126,6 +126,7 @@ module Unop = struct
     | Regexp_plus
     | Regexp_opt
     | Regexp_comp
+  [@@deriving ord]
 
   let equal o1 o2 =
     match (o1, o2) with
@@ -232,6 +233,7 @@ module Binop = struct
     | Regexp_range
     | Regexp_inter
     | Regexp_diff
+  [@@deriving ord]
 
   let equal o1 o2 =
     match (o1, o2) with
@@ -321,6 +323,7 @@ module Relop = struct
     | LeU
     | Ge
     | GeU
+  [@@deriving ord]
 
   let equal op1 op2 =
     match (op1, op2) with
@@ -361,6 +364,7 @@ module Triop = struct
     | String_replace_all
     | String_replace_re
     | String_replace_re_all
+  [@@deriving ord]
 
   let equal op1 op2 =
     match (op1, op2) with
@@ -421,6 +425,7 @@ module Cvtop = struct
     | String_from_int
     | String_to_float
     | String_to_re
+  [@@deriving ord]
 
   let equal op1 op2 =
     match (op1, op2) with
@@ -501,6 +506,7 @@ module Naryop = struct
     | Logor
     | Concat
     | Regexp_union
+  [@@deriving ord]
 
   let equal op1 op2 =
     match (op1, op2) with

--- a/src/smtml/ty.mli
+++ b/src/smtml/ty.mli
@@ -30,6 +30,7 @@ type t =
   | Ty_unit  (** Unit type. *)
   | Ty_regexp  (** Regular expression type. *)
   | Ty_roundingMode
+[@@deriving ord]
 
 (** {1 Type Comparison} *)
 
@@ -94,6 +95,7 @@ module Unop : sig
     | Regexp_plus  (** Kleene plus. *)
     | Regexp_opt  (** Optional. *)
     | Regexp_comp  (** Complement. *)
+  [@@deriving ord]
 
   (** [equal op1 op2] checks if unary operations [op1] and [op2] are equal. *)
   val equal : t -> t -> bool
@@ -145,6 +147,7 @@ module Binop : sig
     | Regexp_range  (** Range of characters. *)
     | Regexp_inter  (** Intersection of regular expressions. *)
     | Regexp_diff  (** Difference of regular expressions. *)
+  [@@deriving ord]
 
   (** [equal op1 op2] checks if binary operations [op1] and [op2] are equal. *)
   val equal : t -> t -> bool
@@ -169,6 +172,7 @@ module Relop : sig
     | LeU  (** Unsigned less than or equal. *)
     | Ge  (** Greater than or equal. *)
     | GeU  (** Unsigned greater than or equal. *)
+  [@@deriving ord]
 
   (** [equal op1 op2] checks if relational operations [op1] and [op2] are equal.
   *)
@@ -201,6 +205,7 @@ module Triop : sig
     | String_replace_re_all
       (** Replace all occurrences using a regular expression.
           (str.replace_re_all String RegLan String) *)
+  [@@deriving ord]
 
   (** [equal op1 op2] checks if ternary operations [op1] and [op2] are equal. *)
   val equal : t -> t -> bool
@@ -247,6 +252,7 @@ module Cvtop : sig
     | String_from_int  (** Convert integer to string. *)
     | String_to_float  (** Convert string to float. *)
     | String_to_re  (** Convert string to regular expression. *)
+  [@@deriving ord]
 
   (** [equal op1 op2] checks if conversion operations [op1] and [op2] are equal.
   *)
@@ -266,6 +272,7 @@ module Naryop : sig
     | Logor  (** Logical OR. *)
     | Concat  (** Concatenation. *)
     | Regexp_union  (** Union of regular expressions. *)
+  [@@deriving ord]
 
   (** [equal op1 op2] checks if n-ary operations [op1] and [op2] are equal. *)
   val equal : t -> t -> bool


### PR DESCRIPTION
This issue starts logging all SMT queries sent to the solver during each test in bench/. Logs are written to a queries_log.jsonl file per test.

What works
- Each query is logged as JSON (hash + assumptions).

Known issues
- No timing or performance info is logged yet.

Next steps
- Add query timing, memory, and CPU metrics.

How to use
```
git clone https://github.com/felixL-K/smtml -b trace-smt-queries
cd smtml && dune b @install && dune install

git clone https://github.com/felixL-K/owi -b trace-queries2
cd owi && dune exec -- testcomp/testcomp.exe <your-test-id>
```
