### PR TITLE
fix normalization error on floats

### DIFF
--- a/src/smtml/expr.ml
+++ b/src/smtml/expr.ml
@@ -344,6 +344,7 @@ let unop ty op hte =
   | Ty.Unop.(Regexp_loop _ | Regexp_star), _ -> raw_unop ty op hte
   | _, Val v -> value (Eval.unop ty op v)
   | Not, Unop (_, Not, hte') -> hte'
+  | Not, Relop (Ty_fp _, _, _, _) -> raw_unop ty op hte
   | Not, Relop (_, _, _, _) -> negate_relop hte
   | Neg, Unop (_, Neg, hte') -> hte'
   | Trim, Cvtop (Ty_real, ToString, _) -> hte

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -614,6 +614,16 @@ let test_simplify_concat_i32_symbol _ =
   let concated = Expr.concat d (Expr.concat c (Expr.concat b a)) in
   check concated x
 
+let test_fp_nan_not_geffects _ =
+  let open Infix in
+  let ty = Ty.Ty_fp 32 in
+  let x = symbol "x" ty in
+  let y = symbol "y" ty in
+  (* x != x makes isNaN(x) *)
+  let expr = Expr.unop ty Not (Expr.relop ty Ge x y) in
+  let expected = Expr.unop ty Not (Expr.relop ty Le y x) in
+  check expr expected
+
 let test_simplify_concat =
   [ "test_simplify_concat_i32_i32" >:: test_simplify_concat_i32_i32
   ; "test_simplify_concat_i32_symbol" >:: test_simplify_concat_i32_symbol
@@ -621,6 +631,7 @@ let test_simplify_concat =
 
 let test_simplify =
   [ "test_simplify_assoc" >:: test_simplify_assoc
+  ; "test_fp_nan_not_geffects" >:: test_fp_nan_not_geffects
   ; "test_simplify_extract" >::: test_simplify_extract
   ; "test_simplify_concat" >::: test_simplify_concat
   ]

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -620,8 +620,8 @@ let test_fp_nan_not_geffects _ =
   let x = symbol "x" ty in
   let y = symbol "y" ty in
   (* x != x makes isNaN(x) *)
-  let expr = Expr.unop ty Not (Expr.relop ty Ge x y) in
-  let expected = Expr.unop ty Not (Expr.relop ty Le y x) in
+  let expr = Expr.unop Ty_bool Not (Expr.relop ty Ge x y) in
+  let expected = Expr.unop Ty_bool Not (Expr.relop ty Le y x) in
   check expr expected
 
 let test_simplify_concat =


### PR DESCRIPTION
An error was introduced with normalization of floats : 
`x < y` is not equivalent to `not(x >= y)` for floats when x or y is nan