### PR TITLE
Patch Expr.relop to accept theory specific types for equality (#394)

### DIFF
--- a/src/smtml/eval.ml
+++ b/src/smtml/eval.ml
@@ -125,6 +125,7 @@ module Int = struct
       | Gt -> ( > )
       | Ge -> ( >= )
       | Eq -> Int.equal
+      | Ne -> fun a b -> not (Int.equal a b)
       | _ ->
         Fmt.failwith {|relop: Unsupported int operator "%a"|} Ty.Relop.pp op
     in


### PR DESCRIPTION
It appears we were already accepting for other theories except integers. Just missing he inequality for ints.

Closes #394 