### PR TITLE
Fix the order of formulas printed by the z3 mapping printer

### DIFF
--- a/src/smtml/z3_mappings.default.ml
+++ b/src/smtml/z3_mappings.default.ml
@@ -588,7 +588,7 @@ module M = struct
     end
 
     module Smtlib = struct
-      let pp ?name ?logic ?status fmt =
+      let pp ?name ?logic ?status fmt l =
         let name = Option.value name ~default:"" in
         let logic =
           Fmt.str "%a"
@@ -601,14 +601,17 @@ module M = struct
           | `Unsat -> "unsat"
           | `Unknown -> "unknown"
         in
-        function
+        match l with
         | [] -> ()
         | [ x ] ->
           Fmt.pf fmt "%s"
             (Z3.SMT.benchmark_to_smtstring ctx name logic status "" [] x)
-        | hd :: tl ->
-          (* Prints formulas in correct order? *)
-          let tl = List.rev tl in
+        | _ :: _ ->
+          let hd, tl =
+            match List.rev l with
+            | hd :: tl -> (hd, List.rev tl)
+            | _ -> assert false
+          in
           Fmt.pf fmt "%s"
             (Z3.SMT.benchmark_to_smtstring ctx name logic status "" tl hd)
     end


### PR DESCRIPTION
Simply selects the last assert in the list, and adds all the other ones as assumptions (which why we redo a `List.rev` on the tail of the reversed list).

If we test by running `smtml to-smt2` on https://github.com/formalsec/smtml/blob/7e1e14511f8f8b14797825a34cd8c7b83ab6bd1a/test/cli/smtml/test_lia.smtml#L1-L16

With this fix the result is: 

<details>
  <summary>New result</summary>
 
```smt
; test_lia.smtml
(set-info :status unknown)
(set-logic ALL)
(declare-fun x () Int)
(declare-fun y () Int)
(declare-fun z () Int)
(assert
 (< 0 x))
(assert
 (<= x 10))
(assert
 (let ((?x16 (+ x y)))
 (let ((?x17 (- ?x16 y)))
 (= ?x17 x))))
(assert
 (let ((?x19 (* x y)))
 (let ((?x20 (div ?x19 y)))
 (= ?x20 x))))
(assert
 (let ((?x22 (rem y x)))
 (< ?x22 10)))
(assert
 (let ((?x25 (^ x 2)))
 (let ((?x27 (/ ?x25 (to_real x))))
 (= ?x27 (to_real (div (* x x) x))))))
(assert
 (let ((?x33 (- z)))
(< ?x33 0)))
(check-sat)
```
</details>

While in the original it was:
<details>
  <summary>Old result</summary>
 
```smt
; test_lia.smtml
(set-info :status unknown)
(set-logic ALL)
(declare-fun z () Int)
(declare-fun x () Int)
(declare-fun y () Int)
(assert
 (let ((?x33 (- z)))
 (< ?x33 0)))
(assert
 (let ((?x25 (^ x 2)))
 (let ((?x27 (/ ?x25 (to_real x))))
 (= ?x27 (to_real (div (* x x) x))))))
(assert
 (let ((?x22 (rem y x)))
 (< ?x22 10)))
(assert
 (let ((?x19 (* x y)))
 (let ((?x20 (div ?x19 y)))
 (= ?x20 x))))
(assert
 (let ((?x16 (+ x y)))
 (let ((?x17 (- ?x16 y)))
 (= ?x17 x))))
(assert
 (<= x 10))
(assert
 (< 0 x))
(check-sat)
```
</details>

Notice that one of the `check-sat`s is lost, that is because it is filtered out in:
https://github.com/formalsec/smtml/blob/7e1e14511f8f8b14797825a34cd8c7b83ab6bd1a/src/bin/cmd_to_smt2.ml#L9-L11