### PR TITLE
add the ability to inline a symbol in a set

### DIFF
--- a/src/smtml/expr_intf.ml
+++ b/src/smtml/expr_intf.ml
@@ -66,6 +66,10 @@ module type S = sig
       an error if the expression is not a relational operation. *)
   val negate_relop : t -> t
 
+  (** [inline_symbol_values symbol_map e] replaces each symbol [e] expressions
+      of [set] by its image in [symbol_map]. *)
+  val inline_symbol_values : t Symbol.Map.t -> t -> t
+
   (** {1 Pretty Printing} *)
 
   (** [pp fmt term] prints a term in a human-readable format using the formatter
@@ -420,6 +424,9 @@ module type S = sig
         of {!to_int}. *)
     val iter : (elt -> unit) -> t -> unit
 
+    (** [map f set] maps all elements of [set] to their image by [f]. *)
+    val map : (elt -> elt) -> t -> t
+
     (** [filter f set] is the subset of [set] that only contains the elements
         that satisfy [f]. [f] is called in the unsigned order of {!to_int}. *)
     val filter : (elt -> bool) -> t -> t
@@ -518,6 +525,10 @@ module type S = sig
     (** [get_symbols exprs] extracts all symbolic variables from a list of
         expressions. *)
     val get_symbols : t -> Symbol.t list
+
+    (** [inline_symbol_values symbol_map set] replaces each symbol in all
+        expressions of [set] by its image in [symbol_map]. *)
+    val inline_symbol_values : elt Symbol.Map.t -> t -> t
   end
 
   (** {1 Bitvectors} *)

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -650,6 +650,36 @@ let test_simplify =
   ; "test_simplify_ptr" >:: test_simplify_ptr
   ]
 
+let test_inline_symbol_values_empty (_ : test_ctxt) =
+  let symbol_map = Symbol.Map.empty in
+  let e =
+    let ty = Ty.Ty_bitv 32 in
+    Infix.symbol "x" ty
+  in
+  let e' = Expr.inline_symbol_values symbol_map e in
+  (* We should not have changed the symbol value, and it should even stay physically equal to its original value. *)
+  assert (e == e')
+
+let test_inline_symbol_values_replace_one (_ : test_ctxt) =
+  let n = Infix.int 42 in
+  let e' =
+    let x =
+      let ty = Ty.Ty_bitv 32 in
+      Symbol.make ty "x"
+    in
+    let symbol_map = Symbol.Map.add x n Symbol.Map.empty in
+    let e = Expr.symbol x in
+    Expr.inline_symbol_values symbol_map e
+  in
+  (* e should now be equal to n because symbol x should have been replaced by n *)
+  assert (e' == n)
+
+let test_inline_symbol_values =
+  [ "test_inline_symbol_values_empty" >:: test_inline_symbol_values_empty
+  ; "test_inline_symbol_values_replace_one"
+    >:: test_inline_symbol_values_replace_one
+  ]
+
 let test_suite =
   "Expression unit tests"
   >::: [ "test_hc" >:: test_hc
@@ -660,6 +690,7 @@ let test_suite =
        ; "test_cvtop" >::: test_cvtop
        ; "test_naryop" >::: test_naryop
        ; "test_simplify" >::: test_simplify
+       ; "test_inline_symbol_values" >::: test_inline_symbol_values
        ]
 
 let () = run_test_tt_main test_suite


### PR DESCRIPTION
This will be used in Owi (or maybe the simplification makes sense directly in Smt.ml, we'll see).

The idea is that, when we add something like `symbol_0 = 42` in the PC. Then, we can propagate the equality and replace `symbol_0` by `42` in order to simplify the PC and save time/solver calls in the remaining execution.

This is a quick draft, I'll finish it soon.