### PR TITLE
Refactor exception handling in operator evaluation

### DIFF
--- a/src/smtml/eval.ml
+++ b/src/smtml/eval.ml
@@ -7,8 +7,6 @@
 (* - https://github.com/WebAssembly/spec/blob/main/interpreter/exec/fxx.ml, and *)
 (* - https://github.com/WebAssembly/spec/blob/main/interpreter/exec *)
 
-(* TODO: This module should be concrete or a part of the reducer *)
-
 type op_type =
   [ `Unop of Ty.Unop.t
   | `Binop of Ty.Binop.t
@@ -26,62 +24,120 @@ let pp_op_type fmt = function
   | `Cvtop op -> Fmt.pf fmt "cvtop '%a'" Ty.Cvtop.pp op
   | `Naryop op -> Fmt.pf fmt "naryop '%a'" Ty.Naryop.pp op
 
+type type_error_info =
+  { index : int
+  ; value : Value.t
+  ; ty : Ty.t
+  ; op : op_type
+  ; msg : string
+  }
+
+type error_kind =
+  [ `Divide_by_zero
+  | `Conversion_to_integer
+  | `Integer_overflow
+  | `Index_out_of_bounds
+  | `Invalid_format_conversion
+  | `Unsupported_operator of op_type * Ty.t
+  | `Unsupported_theory of Ty.t
+  | `Type_error of type_error_info
+  ]
+
+exception Eval_error of error_kind
+
 exception Value of Ty.t
 
-(* FIXME: use snake case instead *)
-exception
-  TypeError of
-    { index : int
-    ; value : Value.t
-    ; ty : Ty.t
-    ; op : op_type
-    ; msg : string
-    }
+(* Exception helpers *)
 
-(* FIXME: use snake case instead *)
-exception DivideByZero
+let eval_error kind = raise (Eval_error kind)
 
-exception Conversion_to_integer
-
-exception Integer_overflow
-
-(* FIXME: use snake case instead *)
-exception Index_out_of_bounds
-
-let of_arg f n v op msg =
-  try f v
-  with Value t -> raise (TypeError { index = n; value = v; ty = t; op; msg })
-[@@inline]
+let type_error n v ty op msg =
+  eval_error (`Type_error { index = n; value = v; ty; op; msg })
 
 let err_str n op ty_expected ty_actual =
   Fmt.str "Argument %d of %a expected type %a but got %a instead." n pp_op_type
     op Ty.pp ty_expected Ty.pp ty_actual
 
+let[@inline] of_arg f n v op =
+  try f v
+  with Value expected_ty ->
+    let actual_ty = Value.type_of v in
+    let msg = err_str n op expected_ty actual_ty in
+    type_error n v expected_ty op msg
+
+(* Coercion helpers *)
+
+let of_int n op v =
+  of_arg (function Int x -> x | _ -> raise_notrace (Value Ty_int)) n v op
+
+let[@inline] to_int x = Value.Int x
+
+let of_real n op v =
+  of_arg (function Real x -> x | _ -> raise_notrace (Value Ty_real)) n v op
+
+let[@inline] to_real x = Value.Real x
+
+let of_bool n op v =
+  of_arg
+    (function
+      | True -> true | False -> false | _ -> raise_notrace (Value Ty_bool) )
+    n v op
+
+let[@inline] to_bool x = if x then Value.True else False
+
+let of_str n op v =
+  of_arg (function Str x -> x | _ -> raise_notrace (Value Ty_str)) n v op
+
+let[@inline] to_str x = Value.Str x
+
+let of_list n op v =
+  of_arg (function List x -> x | _ -> raise_notrace (Value Ty_list)) n v op
+
+let of_bitv n op v =
+  of_arg
+    (function Bitv x -> x | _ -> raise_notrace (Value (Ty_bitv 0)))
+    n v op
+
+let int32_of_bitv n op v = of_bitv n op v |> Bitvector.to_int32
+
+let int64_of_bitv n op v = of_bitv n op v |> Bitvector.to_int64
+
+let[@inline] to_bitv x = Value.Bitv x
+
+let[@inline] bitv_of_int32 x = to_bitv (Bitvector.of_int32 x)
+
+let[@inline] bitv_of_int64 x = to_bitv (Bitvector.of_int64 x)
+
+let of_fp32 i op v : int32 =
+  of_arg
+    (function Num (F32 f) -> f | _ -> raise_notrace (Value (Ty_fp 32)))
+    i v op
+
+let[@inline] to_fp32 (x : int32) = Value.Num (F32 x)
+
+let[@inline] fp32_of_float (x : float) = to_fp32 (Int32.bits_of_float x)
+
+let of_fp64 i op v : int64 =
+  of_arg
+    (function Num (F64 f) -> f | _ -> raise_notrace (Value (Ty_fp 32)))
+    i v op
+
+let[@inline] to_fp64 (x : int64) = Value.Num (F64 x)
+
+let[@inline] fp64_of_float (x : float) = to_fp64 (Int64.bits_of_float x)
+
+(* Operator evaluation *)
+
 module Int = struct
-  let to_value (i : int) : Value.t = Int i [@@inline]
-
-  let of_value (n : int) (op : op_type) (v : Value.t) : int =
-    of_arg
-      (function Int i -> i | _ -> raise_notrace (Value Ty_int))
-      n v op
-      (err_str n op Ty_int (Value.type_of v))
-  [@@inline]
-
-  let _str_value (n : int) (op : op_type) (v : Value.t) : string =
-    of_arg
-      (function Str str -> str | _ -> raise_notrace (Value Ty_str))
-      n v op
-      (err_str n op Ty_str (Value.type_of v))
-
   let unop (op : Ty.Unop.t) (v : Value.t) : Value.t =
     let f =
       match op with
       | Neg -> Int.neg
       | Not -> Int.lognot
       | Abs -> Int.abs
-      | _ -> Fmt.failwith {|unop: Unsupported int operator "%a"|} Ty.Unop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Unop op, Ty_int))
     in
-    to_value (f (of_value 1 (`Unop op) v))
+    to_int (f (of_int 1 (`Unop op) v))
 
   let exp_by_squaring x n =
     let rec exp_by_squaring2 y x n =
@@ -112,10 +168,9 @@ module Int = struct
       | Shl -> Int.shift_left
       | ShrL -> Int.shift_right_logical
       | ShrA -> Int.shift_right
-      | _ ->
-        Fmt.failwith {|binop: Unsupported int operator "%a"|} Ty.Binop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_int))
     in
-    to_value (f (of_value 1 (`Binop op) v1) (of_value 2 (`Binop op) v2))
+    to_int (f (of_int 1 (`Binop op) v1) (of_int 2 (`Binop op) v2))
 
   let relop (op : Ty.Relop.t) (v1 : Value.t) (v2 : Value.t) : bool =
     let f =
@@ -126,10 +181,9 @@ module Int = struct
       | Ge -> ( >= )
       | Eq -> Int.equal
       | Ne -> fun a b -> not (Int.equal a b)
-      | _ ->
-        Fmt.failwith {|relop: Unsupported int operator "%a"|} Ty.Relop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Relop op, Ty_int))
     in
-    f (of_value 1 (`Relop op) v1) (of_value 2 (`Relop op) v2)
+    f (of_int 1 (`Relop op) v1) (of_int 2 (`Relop op) v2)
 
   let of_bool : Value.t -> int = function
     | True -> 1
@@ -139,34 +193,24 @@ module Int = struct
 
   let cvtop (op : Ty.Cvtop.t) (v : Value.t) : Value.t =
     match op with
-    | OfBool -> to_value (of_bool v)
-    | Reinterpret_float ->
-      Int (Int.of_float (match v with Real v -> v | _ -> assert false))
-    | _ -> Fmt.failwith {|cvtop: Unsupported int operator "%a"|} Ty.Cvtop.pp op
+    | OfBool -> to_int (of_bool v)
+    | Reinterpret_float -> Int (Int.of_float (of_real 1 (`Cvtop op) v))
+    | _ -> eval_error (`Unsupported_operator (`Cvtop op, Ty_int))
 end
 
 module Real = struct
-  let to_value (v : float) : Value.t = Real v [@@inline]
-
-  let of_value (n : int) (op : op_type) (v : Value.t) : float =
-    of_arg
-      (function Real v -> v | _ -> raise_notrace (Value Ty_int))
-      n v op
-      (err_str n op Ty_real (Value.type_of v))
-  [@@inline]
-
   let unop (op : Ty.Unop.t) (v : Value.t) : Value.t =
-    let v = of_value 1 (`Unop op) v in
+    let v = of_real 1 (`Unop op) v in
     match op with
-    | Neg -> to_value @@ Float.neg v
-    | Abs -> to_value @@ Float.abs v
-    | Sqrt -> to_value @@ Float.sqrt v
-    | Nearest -> to_value @@ Float.round v
-    | Ceil -> to_value @@ Float.ceil v
-    | Floor -> to_value @@ Float.floor v
-    | Trunc -> to_value @@ Float.trunc v
+    | Neg -> to_real @@ Float.neg v
+    | Abs -> to_real @@ Float.abs v
+    | Sqrt -> to_real @@ Float.sqrt v
+    | Nearest -> to_real @@ Float.round v
+    | Ceil -> to_real @@ Float.ceil v
+    | Floor -> to_real @@ Float.floor v
+    | Trunc -> to_real @@ Float.trunc v
     | Is_nan -> if Float.is_nan v then Value.True else Value.False
-    | _ -> Fmt.failwith {|unop: Unsupported real operator "%a"|} Ty.Unop.pp op
+    | _ -> eval_error (`Unsupported_operator (`Unop op, Ty_real))
 
   let binop (op : Ty.Binop.t) (v1 : Value.t) (v2 : Value.t) : Value.t =
     let f =
@@ -179,10 +223,9 @@ module Real = struct
       | Min -> Float.min
       | Max -> Float.max
       | Pow -> Float.pow
-      | _ ->
-        Fmt.failwith {|binop: Unsupported real operator "%a"|} Ty.Binop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_real))
     in
-    to_value (f (of_value 1 (`Binop op) v1) (of_value 2 (`Binop op) v2))
+    to_real (f (of_real 1 (`Binop op) v1) (of_real 2 (`Binop op) v2))
 
   let relop (op : Ty.Relop.t) (v1 : Value.t) (v2 : Value.t) : bool =
     let f =
@@ -193,44 +236,30 @@ module Real = struct
       | Ge -> Float.Infix.( >= )
       | Eq -> Float.Infix.( = )
       | Ne -> Float.Infix.( <> )
-      | _ ->
-        Fmt.failwith {|relop: Unsupported real operator "%a"|} Ty.Relop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Relop op, Ty_real))
     in
-    f (of_value 1 (`Relop op) v1) (of_value 2 (`Relop op) v2)
+    f (of_real 1 (`Relop op) v1) (of_real 2 (`Relop op) v2)
 
   let cvtop (op : Ty.Cvtop.t) (v : Value.t) : Value.t =
     let op' = `Cvtop op in
     match op with
-    | ToString -> Str (Float.to_string (of_value 1 op' v))
-    | OfString ->
-      let v = match v with Str v -> v | _ -> raise_notrace (Value Ty_str) in
-      begin match Float.of_string_opt v with
-      | None -> raise (Invalid_argument "float_of_int")
-      | Some v -> to_value v
-      end
-    | Reinterpret_int ->
-      let v = match v with Int v -> v | _ -> raise_notrace (Value Ty_int) in
-      to_value (float_of_int v)
-    | Reinterpret_float -> Int (Float.to_int (of_value 1 op' v))
-    | _ -> Fmt.failwith {|cvtop: Unsupported real operator "%a"|} Ty.Cvtop.pp op
+    | ToString -> Str (Float.to_string (of_real 1 op' v))
+    | OfString -> begin
+      match float_of_string_opt (of_str 1 op' v) with
+      | None -> eval_error `Invalid_format_conversion
+      | Some v -> to_real v
+    end
+    | Reinterpret_int -> to_real (float_of_int (of_int 1 op' v))
+    | Reinterpret_float -> to_int (Float.to_int (of_real 1 op' v))
+    | _ -> eval_error (`Unsupported_operator (op', Ty_real))
 end
 
 module Bool = struct
-  let to_value (b : bool) : Value.t = if b then True else False [@@inline]
-
-  let of_value (n : int) (op : op_type) (v : Value.t) : bool =
-    of_arg
-      (function
-        | True -> true | False -> false | _ -> raise_notrace (Value Ty_bool) )
-      n v op
-      (err_str n op Ty_bool (Value.type_of v))
-  [@@inline]
-
   let unop (op : Ty.Unop.t) v =
-    let b = of_value 1 (`Unop op) v in
+    let b = of_bool 1 (`Unop op) v in
     match op with
-    | Not -> to_value (not b)
-    | _ -> Fmt.failwith {|unop: Unsupported bool operator "%a"|} Ty.Unop.pp op
+    | Not -> to_bool (not b)
+    | _ -> eval_error (`Unsupported_operator (`Unop op, Ty_bool))
 
   let xor b1 b2 =
     match (b1, b2) with
@@ -245,47 +274,36 @@ module Bool = struct
       | And -> ( && )
       | Or -> ( || )
       | Xor -> xor
-      | _ ->
-        Fmt.failwith {|binop: Unsupported bool operator "%a"|} Ty.Binop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_bool))
     in
-    to_value (f (of_value 1 (`Binop op) v1) (of_value 2 (`Binop op) v2))
+    to_bool (f (of_bool 1 (`Binop op) v1) (of_bool 2 (`Binop op) v2))
 
   let triop (op : Ty.Triop.t) c v1 v2 =
     match op with
-    | Ite -> ( match of_value 1 (`Triop op) c with true -> v1 | false -> v2 )
-    | _ -> Fmt.failwith {|triop: Unsupported bool operator "%a"|} Ty.Triop.pp op
+    | Ite -> ( match of_bool 1 (`Triop op) c with true -> v1 | false -> v2 )
+    | _ -> eval_error (`Unsupported_operator (`Triop op, Ty_bool))
 
   let relop (op : Ty.Relop.t) v1 v2 =
     match op with
     | Eq -> Value.equal v1 v2
     | Ne -> not (Value.equal v1 v2)
-    | _ -> Fmt.failwith {|relop: Unsupported bool operator "%a"|} Ty.Relop.pp op
+    | _ -> eval_error (`Unsupported_operator (`Relop op, Ty_bool))
 
   let naryop (op : Ty.Naryop.t) vs =
     let b =
       match op with
       | Logand ->
         List.fold_left ( && ) true
-          (List.mapi (fun i -> of_value i (`Naryop op)) vs)
+          (List.mapi (fun i -> of_bool i (`Naryop op)) vs)
       | Logor ->
         List.fold_left ( || ) false
-          (List.mapi (fun i -> of_value i (`Naryop op)) vs)
-      | _ ->
-        Fmt.failwith {|naryop: Unsupported bool operator "%a"|} Ty.Naryop.pp op
+          (List.mapi (fun i -> of_bool i (`Naryop op)) vs)
+      | _ -> eval_error (`Unsupported_operator (`Naryop op, Ty_bool))
     in
-    to_value b
+    to_bool b
 end
 
 module Str = struct
-  let to_value (str : string) : Value.t = Str str [@@inline]
-
-  let of_value (n : int) (op : op_type) (v : Value.t) : string =
-    of_arg
-      (function Str str -> str | _ -> raise_notrace (Value Ty_str))
-      n v op
-      (err_str n op Ty_str (Value.type_of v))
-  [@@inline]
-
   let replace s t t' =
     let len_s = String.length s in
     let len_t = String.length t in
@@ -315,44 +333,46 @@ module Str = struct
   let contains s sub = if indexof s sub 0 < 0 then false else true
 
   let unop (op : Ty.Unop.t) v =
-    let str = of_value 1 (`Unop op) v in
+    let str = of_str 1 (`Unop op) v in
     match op with
-    | Length -> Int.to_value (String.length str)
-    | Trim -> to_value (String.trim str)
-    | _ -> Fmt.failwith {|unop: Unsupported str operator "%a"|} Ty.Unop.pp op
+    | Length -> to_int (String.length str)
+    | Trim -> to_str (String.trim str)
+    | _ -> eval_error (`Unsupported_operator (`Unop op, Ty_str))
 
   let binop (op : Ty.Binop.t) v1 v2 =
     let op' = `Binop op in
-    let str = of_value 1 op' v1 in
+    let str = of_str 1 op' v1 in
     match op with
-    | At -> (
-      let i = Int.of_value 2 op' v2 in
-      try to_value (Fmt.str "%c" (String.get str i))
-      with Invalid_argument _ -> raise Index_out_of_bounds )
+    | At -> begin
+      let i = of_int 2 op' v2 in
+      try to_str (Fmt.str "%c" (String.get str i))
+      with Invalid_argument _ -> eval_error `Index_out_of_bounds
+    end
     | String_prefix ->
-      Bool.to_value (String.starts_with ~prefix:str (of_value 2 op' v2))
-    | String_suffix ->
-      Bool.to_value (String.ends_with ~suffix:str (of_value 2 op' v2))
-    | String_contains -> Bool.to_value (contains str (of_value 2 op' v2))
-    | _ -> Fmt.failwith {|binop: Unsupported str operator "%a"|} Ty.Binop.pp op
+      to_bool (String.starts_with ~prefix:str (of_str 2 op' v2))
+    | String_suffix -> to_bool (String.ends_with ~suffix:str (of_str 2 op' v2))
+    | String_contains -> to_bool (contains str (of_str 2 op' v2))
+    | _ -> eval_error (`Unsupported_operator (op', Ty_str))
 
   let triop (op : Ty.Triop.t) v1 v2 v3 =
     let op' = `Triop op in
-    let str = of_value 1 op' v1 in
+    let str = of_str 1 op' v1 in
     match op with
-    | String_extract ->
-      let i = Int.of_value 2 op' v2 in
-      let len = Int.of_value 3 op' v3 in
-      to_value (String.sub str i len)
+    | String_extract -> begin
+      let i = of_int 2 op' v2 in
+      let len = of_int 3 op' v3 in
+      try to_str (String.sub str i len)
+      with Invalid_argument _ -> eval_error `Index_out_of_bounds
+    end
     | String_replace ->
-      let t = of_value 2 op' v2 in
-      let t' = of_value 2 op' v3 in
-      to_value (replace str t t')
+      let t = of_str 2 op' v2 in
+      let t' = of_str 2 op' v3 in
+      to_str (replace str t t')
     | String_index ->
-      let t = of_value 2 op' v2 in
-      let i = Int.of_value 3 op' v3 in
-      Int.to_value (indexof str t i)
-    | _ -> Fmt.failwith {|triop: Unsupported str operator "%a"|} Ty.Triop.pp op
+      let t = of_str 2 op' v2 in
+      let i = of_int 3 op' v3 in
+      to_int (indexof str t i)
+    | _ -> eval_error (`Unsupported_operator (`Triop op, Ty_str))
 
   let relop (op : Ty.Relop.t) v1 v2 =
     let f =
@@ -363,104 +383,98 @@ module Str = struct
       | Ge -> ( >= )
       | Eq -> ( = )
       | Ne -> ( <> )
-      | _ ->
-        Fmt.failwith {|relop: Unsupported string operator "%a"|} Ty.Relop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Relop op, Ty_str))
     in
     let f x y = f (String.compare x y) 0 in
-    f (of_value 1 (`Relop op) v1) (of_value 2 (`Relop op) v2)
+    f (of_str 1 (`Relop op) v1) (of_str 2 (`Relop op) v2)
 
   let cvtop (op : Ty.Cvtop.t) v =
     let op' = `Cvtop op in
     match op with
     | String_to_code ->
-      let str = of_value 1 op' v in
-      Int.to_value (Char.code str.[0])
+      let str = of_str 1 op' v in
+      to_int (Char.code str.[0])
     | String_from_code ->
-      let code = Int.of_value 1 op' v in
-      to_value (String.make 1 (Char.chr code))
-    | String_to_int ->
-      let s = of_value 1 op' v in
-      let i =
-        match int_of_string_opt s with
-        | None -> raise (Invalid_argument "string_to_int")
-        | Some i -> i
-      in
-      Int.to_value i
-    | String_from_int -> to_value (string_of_int (Int.of_value 1 op' v))
-    | String_to_float ->
-      let s = of_value 1 op' v in
-      let f =
-        match float_of_string_opt s with
-        | None -> raise (Invalid_argument "string_to_float")
-        | Some f -> f
-      in
-      Real.to_value f
-    | _ -> Fmt.failwith {|cvtop: Unsupported str operator "%a"|} Ty.Cvtop.pp op
+      let code = of_int 1 op' v in
+      to_str (String.make 1 (Char.chr code))
+    | String_to_int -> begin
+      let s = of_str 1 op' v in
+      match int_of_string_opt s with
+      | None -> eval_error `Invalid_format_conversion
+      | Some x -> to_int x
+    end
+    | String_from_int -> to_str (string_of_int (of_int 1 op' v))
+    | String_to_float -> begin
+      let s = of_str 1 op' v in
+      match float_of_string_opt s with
+      | None -> eval_error `Invalid_format_conversion
+      | Some f -> to_real f
+    end
+    | _ -> eval_error (`Unsupported_operator (`Cvtop op, Ty_str))
 
   let naryop (op : Ty.Naryop.t) vs =
     let op' = `Naryop op in
     match op with
-    | Concat -> to_value (String.concat "" (List.map (of_value 0 op') vs))
-    | _ ->
-      Fmt.failwith {|naryop: Unsupported str operator "%a"|} Ty.Naryop.pp op
+    | Concat -> to_str (String.concat "" (List.map (of_str 0 op') vs))
+    | _ -> eval_error (`Unsupported_operator (`Naryop op, Ty_str))
 end
 
 module Lst = struct
-  let of_value (n : int) (op : op_type) (v : Value.t) : Value.t list =
-    of_arg
-      (function List lst -> lst | _ -> raise_notrace (Value Ty_list))
-      n v op
-      (err_str n op Ty_list (Value.type_of v))
-  [@@inline]
-
   let unop (op : Ty.Unop.t) (v : Value.t) : Value.t =
-    let lst = of_value 1 (`Unop op) v in
+    let lst = of_list 1 (`Unop op) v in
     match op with
-    | Head -> begin match lst with hd :: _tl -> hd | [] -> assert false end
-    | Tail -> begin
-      match lst with _hd :: tl -> List tl | [] -> assert false
+    | Head -> begin
+      (* FIXME: Exception handling *)
+      match lst with
+      | hd :: _tl -> hd
+      | [] -> assert false
     end
-    | Length -> Int.to_value (List.length lst)
+    | Tail -> begin
+      (* FIXME: Exception handling *)
+      match lst with
+      | _hd :: tl -> List tl
+      | [] -> assert false
+    end
+    | Length -> to_int (List.length lst)
     | Reverse -> List (List.rev lst)
-    | _ -> Fmt.failwith {|unop: Unsupported list operator "%a"|} Ty.Unop.pp op
+    | _ -> eval_error (`Unsupported_operator (`Unop op, Ty_list))
 
   let binop (op : Ty.Binop.t) v1 v2 =
     let op' = `Binop op in
     match op with
     | At ->
-      let lst = of_value 1 op' v1 in
-      let i = Int.of_value 2 op' v2 in
+      let lst = of_list 1 op' v1 in
+      let i = of_int 2 op' v2 in
       (* TODO: change datastructure? *)
       begin match List.nth_opt lst i with
-      | None -> raise Index_out_of_bounds
+      | None -> eval_error `Index_out_of_bounds
       | Some v -> v
       end
-    | List_cons -> List (v1 :: of_value 1 op' v2)
-    | List_append -> List (of_value 1 op' v1 @ of_value 2 op' v2)
-    | _ -> Fmt.failwith {|binop: Unsupported list operator "%a"|} Ty.Binop.pp op
+    | List_cons -> List (v1 :: of_list 1 op' v2)
+    | List_append -> List (of_list 1 op' v1 @ of_list 2 op' v2)
+    | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_list))
 
   let triop (op : Ty.Triop.t) (v1 : Value.t) (v2 : Value.t) (v3 : Value.t) :
     Value.t =
     let op' = `Triop op in
     match op with
     | List_set ->
-      let lst = of_value 1 op' v1 in
-      let i = Int.of_value 2 op' v2 in
+      let lst = of_list 1 op' v1 in
+      let i = of_int 2 op' v2 in
       let rec set i lst v acc =
         match (i, lst) with
         | 0, _ :: tl -> List.rev_append acc (v :: tl)
         | i, hd :: tl -> set (i - 1) tl v (hd :: acc)
-        | _, [] -> raise Index_out_of_bounds
+        | _, [] -> eval_error `Index_out_of_bounds
       in
       List (set i lst v3 [])
-    | _ -> Fmt.failwith {|triop: Unsupported list operator "%a"|} Ty.Triop.pp op
+    | _ -> eval_error (`Unsupported_operator (`Triop op, Ty_list))
 
   let naryop (op : Ty.Naryop.t) (vs : Value.t list) : Value.t =
     let op' = `Naryop op in
     match op with
-    | Concat -> List (List.concat_map (of_value 0 op') vs)
-    | _ ->
-      Fmt.failwith {|naryop: Unsupported list operator "%a"|} Ty.Naryop.pp op
+    | Concat -> List (List.concat_map (of_list 0 op') vs)
+    | _ -> eval_error (`Unsupported_operator (`Naryop op, Ty_list))
 end
 
 module I64 = struct
@@ -470,26 +484,9 @@ module I64 = struct
 end
 
 module Bitv = struct
-  let to_value bv : Value.t = Bitv bv [@@inline]
-
-  let i32_to_value v = to_value @@ Bitvector.of_int32 v
-
-  let i64_to_value v = to_value @@ Bitvector.of_int64 v
-
-  let of_value (n : int) (op : op_type) (v : Value.t) : Bitvector.t =
-    let todo = Ty.Ty_bitv 32 in
-    of_arg
-      (function Bitv bv -> bv | _ -> raise_notrace (Value todo))
-      n v op
-      (err_str n op todo (Value.type_of v))
-
-  let i32_of_value n op v = of_value n op v |> Bitvector.to_int32
-
-  let i64_of_value n op v = of_value n op v |> Bitvector.to_int64
-
   let unop op bv =
-    let bv = of_value 1 (`Unop op) bv in
-    to_value
+    let bv = of_bitv 1 (`Unop op) bv in
+    to_bitv
     @@
     match op with
     | Ty.Unop.Neg -> Bitvector.neg bv
@@ -498,12 +495,13 @@ module Bitv = struct
     | Ctz -> Bitvector.ctz bv
     | Popcnt -> Bitvector.popcnt bv
     | _ ->
-      Fmt.failwith {|unop: Unsupported bitvectore operator "%a"|} Ty.Unop.pp op
+      eval_error
+        (`Unsupported_operator (`Unop op, Ty_bitv (Bitvector.numbits bv)))
 
   let binop op bv1 bv2 =
-    let bv1 = of_value 1 (`Binop op) bv1 in
-    let bv2 = of_value 2 (`Binop op) bv2 in
-    to_value
+    let bv1 = of_bitv 1 (`Binop op) bv1 in
+    let bv2 = of_bitv 2 (`Binop op) bv2 in
+    to_bitv
     @@
     match op with
     | Ty.Binop.Add -> Bitvector.add bv1 bv2
@@ -521,12 +519,11 @@ module Bitv = struct
     | ShrA -> Bitvector.ashr bv1 bv2
     | Rotl -> Bitvector.rotate_left bv1 bv2
     | Rotr -> Bitvector.rotate_right bv1 bv2
-    | _ ->
-      Fmt.failwith {|binop: unsupported bitvector operator "%a"|} Ty.Binop.pp op
+    | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_bitv 0))
 
   let relop op bv1 bv2 =
-    let bv1 = of_value 1 (`Relop op) bv1 in
-    let bv2 = of_value 2 (`Relop op) bv2 in
+    let bv1 = of_bitv 1 (`Relop op) bv1 in
+    let bv2 = of_bitv 2 (`Relop op) bv2 in
     match op with
     | Ty.Relop.Lt -> Bitvector.lt bv1 bv2
     | LtU -> Bitvector.lt_u bv1 bv2
@@ -541,62 +538,43 @@ module Bitv = struct
 end
 
 module F32 = struct
-  let to_float (v : int32) : float = Int32.float_of_bits v [@@inline]
-
-  let of_float (v : float) : int32 = Int32.bits_of_float v [@@inline]
-
-  let to_value (f : int32) : Value.t = Num (F32 f) [@@inline]
-
-  let to_value' (f : float) : Value.t = to_value @@ of_float f [@@inline]
-
-  let of_value (i : int) (op : op_type) (v : Value.t) : int32 =
-    of_arg
-      (function Num (F32 f) -> f | _ -> raise_notrace (Value (Ty_fp 32)))
-      i v op
-      (err_str i op (Ty_fp 32) (Value.type_of v))
-  [@@inline]
-
-  let of_value' (i : int) (op : op_type) (v : Value.t) : float =
-    of_value i op v |> to_float
-  [@@inline]
-
   (* Stolen from Owi *)
   let abs x = Int32.logand x Int32.max_int
 
   let neg x = Int32.logxor x Int32.min_int
 
   let unop (op : Ty.Unop.t) (v : Value.t) : Value.t =
-    let f = to_float @@ of_value 1 (`Unop op) v in
+    let f = Int32.float_of_bits (of_fp32 1 (`Unop op) v) in
     match op with
-    | Neg -> to_value @@ neg @@ of_value 1 (`Unop op) v
-    | Abs -> to_value @@ abs @@ of_value 1 (`Unop op) v
-    | Sqrt -> to_value' @@ Float.sqrt f
-    | Nearest -> to_value' @@ Float.round f
-    | Ceil -> to_value' @@ Float.ceil f
-    | Floor -> to_value' @@ Float.floor f
-    | Trunc -> to_value' @@ Float.trunc f
+    | Neg -> to_fp32 @@ neg @@ of_fp32 1 (`Unop op) v
+    | Abs -> to_fp32 @@ abs @@ of_fp32 1 (`Unop op) v
+    | Sqrt -> fp32_of_float @@ Float.sqrt f
+    | Nearest -> fp32_of_float @@ Float.round f
+    | Ceil -> fp32_of_float @@ Float.ceil f
+    | Floor -> fp32_of_float @@ Float.floor f
+    | Trunc -> fp32_of_float @@ Float.trunc f
     | Is_nan -> if Float.is_nan f then Value.True else Value.False
-    | _ -> Fmt.failwith {|unop: Unsupported f32 operator "%a"|} Ty.Unop.pp op
+    | _ -> eval_error (`Unsupported_operator (`Unop op, Ty_fp 32))
 
   (* Stolen from Owi *)
   let copy_sign x y = Int32.logor (abs x) (Int32.logand y Int32.min_int)
 
   let binop (op : Ty.Binop.t) (v1 : Value.t) (v2 : Value.t) : Value.t =
-    let a = of_value' 1 (`Binop op) v1 in
-    let b = of_value' 1 (`Binop op) v2 in
+    let a = Int32.float_of_bits @@ of_fp32 1 (`Binop op) v1 in
+    let b = Int32.float_of_bits @@ of_fp32 1 (`Binop op) v2 in
     match op with
-    | Add -> to_value' @@ Float.add a b
-    | Sub -> to_value' @@ Float.sub a b
-    | Mul -> to_value' @@ Float.mul a b
-    | Div -> to_value' @@ Float.div a b
-    | Rem -> to_value' @@ Float.rem a b
-    | Min -> to_value' @@ Float.min a b
-    | Max -> to_value' @@ Float.max a b
+    | Add -> fp32_of_float @@ Float.add a b
+    | Sub -> fp32_of_float @@ Float.sub a b
+    | Mul -> fp32_of_float @@ Float.mul a b
+    | Div -> fp32_of_float @@ Float.div a b
+    | Rem -> fp32_of_float @@ Float.rem a b
+    | Min -> fp32_of_float @@ Float.min a b
+    | Max -> fp32_of_float @@ Float.max a b
     | Copysign ->
-      let a = of_value 1 (`Binop op) v1 in
-      let b = of_value 1 (`Binop op) v2 in
-      to_value (copy_sign a b)
-    | _ -> Fmt.failwith {|binop: Unsupported f32 operator "%a"|} Ty.Binop.pp op
+      let a = of_fp32 1 (`Binop op) v1 in
+      let b = of_fp32 1 (`Binop op) v2 in
+      to_fp32 (copy_sign a b)
+    | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_fp 32))
 
   let relop (op : Ty.Relop.t) (v1 : Value.t) (v2 : Value.t) : bool =
     let f =
@@ -607,68 +585,50 @@ module F32 = struct
       | Le -> Float.Infix.( <= )
       | Gt -> Float.Infix.( > )
       | Ge -> Float.Infix.( >= )
-      | _ ->
-        Fmt.failwith {|relop: Unsupported f32 operator "%a"|} Ty.Relop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Relop op, Ty_fp 32))
     in
-    f (of_value' 1 (`Relop op) v1) (of_value' 2 (`Relop op) v2)
+    let a = Int32.float_of_bits @@ of_fp32 1 (`Relop op) v1 in
+    let b = Int32.float_of_bits @@ of_fp32 2 (`Relop op) v2 in
+    f a b
 end
 
 module F64 = struct
-  let to_float (v : int64) : float = Int64.float_of_bits v [@@inline]
-
-  let of_float (v : float) : int64 = Int64.bits_of_float v [@@inline]
-
-  let to_value (f : int64) : Value.t = Num (F64 f) [@@inline]
-
-  let to_value' (f : float) : Value.t = to_value @@ of_float f [@@inline]
-
-  let of_value (i : int) (op : op_type) (v : Value.t) : int64 =
-    of_arg
-      (function Num (F64 f) -> f | _ -> raise_notrace (Value (Ty_fp 64)))
-      i v op
-      (err_str i op (Ty_fp 64) (Value.type_of v))
-  [@@inline]
-
-  let of_value' (i : int) (op : op_type) (v : Value.t) : float =
-    of_value i op v |> to_float
-  [@@inline]
-
   (* Stolen from owi *)
   let abs x = Int64.logand x Int64.max_int
 
   let neg x = Int64.logxor x Int64.min_int
 
   let unop (op : Ty.Unop.t) (v : Value.t) : Value.t =
-    let f = of_value' 1 (`Unop op) v in
+    let f = Int64.float_of_bits @@ of_fp64 1 (`Unop op) v in
     match op with
-    | Neg -> to_value @@ neg @@ of_value 1 (`Unop op) v
-    | Abs -> to_value @@ abs @@ of_value 1 (`Unop op) v
-    | Sqrt -> to_value' @@ Float.sqrt f
-    | Nearest -> to_value' @@ Float.round f
-    | Ceil -> to_value' @@ Float.ceil f
-    | Floor -> to_value' @@ Float.floor f
-    | Trunc -> to_value' @@ Float.trunc f
+    | Neg -> to_fp64 @@ neg @@ of_fp64 1 (`Unop op) v
+    | Abs -> to_fp64 @@ abs @@ of_fp64 1 (`Unop op) v
+    | Sqrt -> fp64_of_float @@ Float.sqrt f
+    | Nearest -> fp64_of_float @@ Float.round f
+    | Ceil -> fp64_of_float @@ Float.ceil f
+    | Floor -> fp64_of_float @@ Float.floor f
+    | Trunc -> fp64_of_float @@ Float.trunc f
     | Is_nan -> if Float.is_nan f then Value.True else Value.False
     | _ -> Fmt.failwith {|unop: Unsupported f32 operator "%a"|} Ty.Unop.pp op
 
   let copy_sign x y = Int64.logor (abs x) (Int64.logand y Int64.min_int)
 
   let binop (op : Ty.Binop.t) (v1 : Value.t) (v2 : Value.t) : Value.t =
-    let a = of_value' 1 (`Binop op) v1 in
-    let b = of_value' 1 (`Binop op) v2 in
+    let a = Int64.float_of_bits @@ of_fp64 1 (`Binop op) v1 in
+    let b = Int64.float_of_bits @@ of_fp64 2 (`Binop op) v2 in
     match op with
-    | Add -> to_value' @@ Float.add a b
-    | Sub -> to_value' @@ Float.sub a b
-    | Mul -> to_value' @@ Float.mul a b
-    | Div -> to_value' @@ Float.div a b
-    | Rem -> to_value' @@ Float.rem a b
-    | Min -> to_value' @@ Float.min a b
-    | Max -> to_value' @@ Float.max a b
+    | Add -> fp64_of_float @@ Float.add a b
+    | Sub -> fp64_of_float @@ Float.sub a b
+    | Mul -> fp64_of_float @@ Float.mul a b
+    | Div -> fp64_of_float @@ Float.div a b
+    | Rem -> fp64_of_float @@ Float.rem a b
+    | Min -> fp64_of_float @@ Float.min a b
+    | Max -> fp64_of_float @@ Float.max a b
     | Copysign ->
-      let a = of_value 1 (`Binop op) v1 in
-      let b = of_value 1 (`Binop op) v2 in
-      to_value @@ copy_sign a b
-    | _ -> Fmt.failwith {|binop: Unsupported f32 operator "%a"|} Ty.Binop.pp op
+      let a = of_fp64 1 (`Binop op) v1 in
+      let b = of_fp64 2 (`Binop op) v2 in
+      to_fp64 @@ copy_sign a b
+    | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_fp 64))
 
   let relop (op : Ty.Relop.t) (v1 : Value.t) (v2 : Value.t) : bool =
     let f =
@@ -679,57 +639,54 @@ module F64 = struct
       | Le -> Float.Infix.( <= )
       | Gt -> Float.Infix.( > )
       | Ge -> Float.Infix.( >= )
-      | _ ->
-        Fmt.failwith {|relop: Unsupported f32 operator "%a"|} Ty.Relop.pp op
+      | _ -> eval_error (`Unsupported_operator (`Relop op, Ty_fp 64))
     in
-    f (of_value' 1 (`Relop op) v1) (of_value' 2 (`Relop op) v2)
+    let a = Int64.float_of_bits @@ of_fp64 1 (`Relop op) v1 in
+    let b = Int64.float_of_bits @@ of_fp64 2 (`Relop op) v2 in
+    f a b
 end
 
 module I32CvtOp = struct
-  (* let extend_s (n : int) (x : int32) : int32 = *)
-  (*   let shift = 32 - n in *)
-  (*   Int32.(shift_right (shift_left x shift) shift) *)
-
   let trunc_f32_s (x : int32) =
-    if Int32.Infix.(x <> x) then raise Conversion_to_integer
+    if Int32.Infix.(x <> x) then eval_error `Conversion_to_integer
     else
-      let xf = F32.to_float x in
+      let xf = Int32.float_of_bits x in
       if
         Float.Infix.(
           xf >= -.Int32.(to_float min_int) || xf < Int32.(to_float min_int) )
-      then raise Integer_overflow
+      then eval_error `Integer_overflow
       else Int32.of_float xf
 
   let trunc_f32_u (x : int32) =
-    if Int32.Infix.(x <> x) then raise Conversion_to_integer
+    if Int32.Infix.(x <> x) then eval_error `Conversion_to_integer
     else
-      let xf = F32.to_float x in
+      let xf = Int32.float_of_bits x in
       if Float.Infix.(xf >= -.Int32.(to_float min_int) *. 2.0 || xf <= -1.0)
-      then raise Integer_overflow
+      then eval_error `Integer_overflow
       else Int32.of_float xf
 
   let trunc_f64_s (x : int64) =
-    if Int64.Infix.(x <> x) then raise Conversion_to_integer
+    if Int64.Infix.(x <> x) then eval_error `Conversion_to_integer
     else
-      let xf = F64.to_float x in
+      let xf = Int64.float_of_bits x in
       if
         Float.Infix.(
           xf >= -.Int64.(to_float min_int) || xf < Int64.(to_float min_int) )
-      then raise Integer_overflow
+      then eval_error `Integer_overflow
       else Int32.of_float xf
 
   let trunc_f64_u (x : int64) =
-    if Int64.Infix.(x <> x) then raise Conversion_to_integer
+    if Int64.Infix.(x <> x) then eval_error `Conversion_to_integer
     else
-      let xf = F64.to_float x in
+      let xf = Int64.float_of_bits x in
       if Float.Infix.(xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0)
-      then raise Integer_overflow
+      then eval_error `Integer_overflow
       else Int32.of_float xf
 
   let trunc_sat_f32_s x =
     if Int32.Infix.(x <> x) then 0l
     else
-      let xf = F32.to_float x in
+      let xf = Int32.float_of_bits x in
       if Float.Infix.(xf < Int32.(to_float min_int)) then Int32.min_int
       else if Float.Infix.(xf >= -.Int32.(to_float min_int)) then Int32.max_int
       else Int32.of_float xf
@@ -737,7 +694,7 @@ module I32CvtOp = struct
   let trunc_sat_f32_u x =
     if Int32.Infix.(x <> x) then 0l
     else
-      let xf = F32.to_float x in
+      let xf = Int32.float_of_bits x in
       if Float.Infix.(xf <= -1.0) then 0l
       else if Float.Infix.(xf >= -.Int32.(to_float min_int) *. 2.0) then -1l
       else Int32.of_float xf
@@ -745,7 +702,7 @@ module I32CvtOp = struct
   let trunc_sat_f64_s x =
     if Int64.Infix.(x <> x) then 0l
     else
-      let xf = F64.to_float x in
+      let xf = Int64.float_of_bits x in
       if Float.Infix.(xf < Int64.(to_float min_int)) then Int32.min_int
       else if Float.Infix.(xf >= -.Int64.(to_float min_int)) then Int32.max_int
       else Int32.of_float xf
@@ -753,7 +710,7 @@ module I32CvtOp = struct
   let trunc_sat_f64_u x =
     if Int64.Infix.(x <> x) then 0l
     else
-      let xf = F64.to_float x in
+      let xf = Int64.float_of_bits x in
       if Float.Infix.(xf <= -1.0) then 0l
       else if Float.Infix.(xf >= -.Int64.(to_float min_int) *. 2.0) then -1l
       else Int32.of_float xf
@@ -761,74 +718,62 @@ module I32CvtOp = struct
   let cvtop op v =
     let op' = `Cvtop op in
     match op with
-    | Ty.Cvtop.WrapI64 ->
-      Bitv.i32_to_value (Int64.to_int32 (Bitv.i64_of_value 1 op' v))
-    | TruncSF32 -> Bitv.i32_to_value (trunc_f32_s (F32.of_value 1 op' v))
-    | TruncUF32 -> Bitv.i32_to_value (trunc_f32_u (F32.of_value 1 op' v))
-    | TruncSF64 -> Bitv.i32_to_value (trunc_f64_s (F64.of_value 1 op' v))
-    | TruncUF64 -> Bitv.i32_to_value (trunc_f64_u (F64.of_value 1 op' v))
-    | Trunc_sat_f32_s ->
-      Bitv.i32_to_value (trunc_sat_f32_s (F32.of_value 1 op' v))
-    | Trunc_sat_f32_u ->
-      Bitv.i32_to_value (trunc_sat_f32_u (F32.of_value 1 op' v))
-    | Trunc_sat_f64_s ->
-      Bitv.i32_to_value (trunc_sat_f64_s (F64.of_value 1 op' v))
-    | Trunc_sat_f64_u ->
-      Bitv.i32_to_value (trunc_sat_f64_u (F64.of_value 1 op' v))
-    | Reinterpret_float -> Bitv.i32_to_value (F32.of_value 1 op' v)
-    | Sign_extend n ->
-      Bitv.to_value (Bitvector.sign_extend n (Bitv.of_value 1 op' v))
-    | Zero_extend n ->
-      Bitv.to_value (Bitvector.zero_extend n (Bitv.of_value 1 op' v))
-    | OfBool -> v (* already a num here *)
-    | ToBool | _ ->
-      Fmt.failwith {|cvtop: Unsupported i32 operator "%a"|} Ty.Cvtop.pp op
+    | Ty.Cvtop.WrapI64 -> bitv_of_int32 (Int64.to_int32 (int64_of_bitv 1 op' v))
+    | TruncSF32 -> bitv_of_int32 (trunc_f32_s (of_fp32 1 op' v))
+    | TruncUF32 -> bitv_of_int32 (trunc_f32_u (of_fp32 1 op' v))
+    | TruncSF64 -> bitv_of_int32 (trunc_f64_s (of_fp64 1 op' v))
+    | TruncUF64 -> bitv_of_int32 (trunc_f64_u (of_fp64 1 op' v))
+    | Trunc_sat_f32_s -> bitv_of_int32 (trunc_sat_f32_s (of_fp32 1 op' v))
+    | Trunc_sat_f32_u -> bitv_of_int32 (trunc_sat_f32_u (of_fp32 1 op' v))
+    | Trunc_sat_f64_s -> bitv_of_int32 (trunc_sat_f64_s (of_fp64 1 op' v))
+    | Trunc_sat_f64_u -> bitv_of_int32 (trunc_sat_f64_u (of_fp64 1 op' v))
+    | Reinterpret_float -> bitv_of_int32 (of_fp32 1 op' v)
+    | Sign_extend n -> to_bitv (Bitvector.sign_extend n (of_bitv 1 op' v))
+    | Zero_extend n -> to_bitv (Bitvector.zero_extend n (of_bitv 1 op' v))
+    | OfBool -> v (* v is already a number here *)
+    | ToBool | _ -> eval_error (`Unsupported_operator (op', Ty_bitv 32))
 end
 
 module I64CvtOp = struct
-  (* let extend_s n x = *)
-  (*   let shift = 64 - n in *)
-  (*   Int64.(shift_right (shift_left x shift) shift) *)
-
   let extend_i32_u (x : int32) =
     Int64.(logand (of_int32 x) 0x0000_0000_ffff_ffffL)
 
   let trunc_f32_s (x : int32) =
-    if Int32.Infix.(x <> x) then raise Conversion_to_integer
+    if Int32.Infix.(x <> x) then eval_error `Conversion_to_integer
     else
-      let xf = F32.to_float x in
+      let xf = Int32.float_of_bits x in
       if
         Float.Infix.(
           xf >= -.Int64.(to_float min_int) || xf < Int64.(to_float min_int) )
-      then raise Integer_overflow
+      then eval_error `Integer_overflow
       else Int64.of_float xf
 
   let trunc_f32_u (x : int32) =
-    if Int32.Infix.(x <> x) then raise Conversion_to_integer
+    if Int32.Infix.(x <> x) then eval_error `Conversion_to_integer
     else
-      let xf = F32.to_float x in
+      let xf = Int32.float_of_bits x in
       if Float.Infix.(xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0)
-      then raise Integer_overflow
+      then eval_error `Integer_overflow
       else if Float.Infix.(xf >= -.Int64.(to_float min_int)) then
         Int64.(logxor (of_float (xf -. 0x1p63)) min_int)
       else Int64.of_float xf
 
   let trunc_f64_s (x : int64) =
-    if Int64.Infix.(x <> x) then raise Conversion_to_integer
+    if Int64.Infix.(x <> x) then eval_error `Conversion_to_integer
     else
-      let xf = F64.to_float x in
+      let xf = Int64.float_of_bits x in
       if
         Float.Infix.(
           xf >= -.Int64.(to_float min_int) || xf < Int64.(to_float min_int) )
-      then raise Integer_overflow
+      then eval_error `Integer_overflow
       else Int64.of_float xf
 
   let trunc_f64_u (x : int64) =
-    if Int64.Infix.(x <> x) then raise Conversion_to_integer
+    if Int64.Infix.(x <> x) then eval_error `Conversion_to_integer
     else
-      let xf = F64.to_float x in
+      let xf = Int64.float_of_bits x in
       if Float.Infix.(xf >= -.Int64.(to_float min_int) *. 2.0 || xf <= -1.0)
-      then raise Integer_overflow
+      then eval_error `Integer_overflow
       else if Float.Infix.(xf >= -.Int64.(to_float min_int)) then
         Int64.(logxor (of_float (xf -. 0x1p63)) min_int)
       else Int64.of_float xf
@@ -836,7 +781,7 @@ module I64CvtOp = struct
   let trunc_sat_f32_s (x : int32) =
     if Int32.Infix.(x <> x) then 0L
     else
-      let xf = F32.to_float x in
+      let xf = Int32.float_of_bits x in
       if Float.Infix.(xf < Int64.(to_float min_int)) then Int64.min_int
       else if Float.Infix.(xf >= -.Int64.(to_float min_int)) then Int64.max_int
       else Int64.of_float xf
@@ -844,7 +789,7 @@ module I64CvtOp = struct
   let trunc_sat_f32_u (x : int32) =
     if Int32.Infix.(x <> x) then 0L
     else
-      let xf = F32.to_float x in
+      let xf = Int32.float_of_bits x in
       if Float.Infix.(xf <= -1.0) then 0L
       else if Float.Infix.(xf >= -.Int64.(to_float min_int) *. 2.0) then -1L
       else if Float.Infix.(xf >= -.Int64.(to_float min_int)) then
@@ -854,7 +799,7 @@ module I64CvtOp = struct
   let trunc_sat_f64_s (x : int64) =
     if Int64.Infix.(x <> x) then 0L
     else
-      let xf = F64.to_float x in
+      let xf = Int64.float_of_bits x in
       if Float.Infix.(xf < Int64.(to_float min_int)) then Int64.min_int
       else if Float.Infix.(xf >= -.Int64.(to_float min_int)) then Int64.max_int
       else Int64.of_float xf
@@ -862,7 +807,7 @@ module I64CvtOp = struct
   let trunc_sat_f64_u (x : int64) =
     if Int64.Infix.(x <> x) then 0L
     else
-      let xf = F64.to_float x in
+      let xf = Int64.float_of_bits x in
       if Float.Infix.(xf <= -1.0) then 0L
       else if Float.Infix.(xf >= -.Int64.(to_float min_int) *. 2.0) then -1L
       else if Float.Infix.(xf >= -.Int64.(to_float min_int)) then
@@ -872,40 +817,25 @@ module I64CvtOp = struct
   let cvtop (op : Ty.Cvtop.t) (v : Value.t) : Value.t =
     let op' = `Cvtop op in
     match op with
-    | Sign_extend n ->
-      Bitv.to_value (Bitvector.sign_extend n (Bitv.of_value 1 op' v))
-    | Zero_extend n ->
-      Bitv.to_value (Bitvector.zero_extend n (Bitv.of_value 1 op' v))
-    | TruncSF32 -> Bitv.i64_to_value (trunc_f32_s (F32.of_value 1 op' v))
-    | TruncUF32 -> Bitv.i64_to_value (trunc_f32_u (F32.of_value 1 op' v))
-    | TruncSF64 -> Bitv.i64_to_value (trunc_f64_s (F64.of_value 1 op' v))
-    | TruncUF64 -> Bitv.i64_to_value (trunc_f64_u (F64.of_value 1 op' v))
-    | Trunc_sat_f32_s ->
-      Bitv.i64_to_value (trunc_sat_f32_s (F32.of_value 1 op' v))
-    | Trunc_sat_f32_u ->
-      Bitv.i64_to_value (trunc_sat_f32_u (F32.of_value 1 op' v))
-    | Trunc_sat_f64_s ->
-      Bitv.i64_to_value (trunc_sat_f64_s (F64.of_value 1 op' v))
-    | Trunc_sat_f64_u ->
-      Bitv.i64_to_value (trunc_sat_f64_u (F64.of_value 1 op' v))
-    | Reinterpret_float -> Bitv.i64_to_value (F64.of_value 1 op' v)
-    | WrapI64 ->
-      raise
-        (TypeError
-           { index = 1
-           ; value = v
-           ; ty = Ty_bitv 64
-           ; op = `Cvtop WrapI64
-           ; msg = "Cannot wrapI64 on an I64"
-           } )
-    | ToBool | OfBool | _ ->
-      Fmt.failwith {|cvtop: Unsupported i64 operator "%a"|} Ty.Cvtop.pp op
+    | Sign_extend n -> to_bitv (Bitvector.sign_extend n (of_bitv 1 op' v))
+    | Zero_extend n -> to_bitv (Bitvector.zero_extend n (of_bitv 1 op' v))
+    | TruncSF32 -> bitv_of_int64 (trunc_f32_s (of_fp32 1 op' v))
+    | TruncUF32 -> bitv_of_int64 (trunc_f32_u (of_fp32 1 op' v))
+    | TruncSF64 -> bitv_of_int64 (trunc_f64_s (of_fp64 1 op' v))
+    | TruncUF64 -> bitv_of_int64 (trunc_f64_u (of_fp64 1 op' v))
+    | Trunc_sat_f32_s -> bitv_of_int64 (trunc_sat_f32_s (of_fp32 1 op' v))
+    | Trunc_sat_f32_u -> bitv_of_int64 (trunc_sat_f32_u (of_fp32 1 op' v))
+    | Trunc_sat_f64_s -> bitv_of_int64 (trunc_sat_f64_s (of_fp64 1 op' v))
+    | Trunc_sat_f64_u -> bitv_of_int64 (trunc_sat_f64_u (of_fp64 1 op' v))
+    | Reinterpret_float -> bitv_of_int64 (of_fp64 1 op' v)
+    | WrapI64 -> type_error 1 v (Ty_bitv 64) op' "Cannot wrapI64 on an I64"
+    | ToBool | OfBool | _ -> eval_error (`Unsupported_operator (op', Ty_bitv 64))
 end
 
 module F32CvtOp = struct
   let demote_f64 x =
-    let xf = F64.to_float x in
-    if Float.Infix.(xf = xf) then F32.of_float xf
+    let xf = Int64.float_of_bits x in
+    if Float.Infix.(xf = xf) then Int32.bits_of_float xf
     else
       let nan64bits = x in
       let sign_field =
@@ -917,17 +847,17 @@ module F32CvtOp = struct
       let fields = Int64.logor sign_field significand_field in
       Int32.logor 0x7fc0_0000l (Int64.to_int32 fields)
 
-  let convert_i32_s x = F32.of_float (Int32.to_float x)
+  let convert_i32_s x = Int32.bits_of_float (Int32.to_float x)
 
   let convert_i32_u x =
-    F32.of_float
+    Int32.bits_of_float
       Int32.(
         Int32.Infix.(
           if x >= 0l then to_float x
           else to_float (logor (shift_right_logical x 1) (logand x 1l)) *. 2.0 ) )
 
   let convert_i64_s x =
-    F32.of_float
+    Int32.bits_of_float
       Int64.(
         Int64.Infix.(
           if abs x < 0x10_0000_0000_0000L then to_float x
@@ -936,7 +866,7 @@ module F32CvtOp = struct
             to_float (logor (shift_right x 12) r) *. 0x1p12 ) )
 
   let convert_i64_u x =
-    F32.of_float
+    Int32.bits_of_float
       Int64.(
         Int64.Infix.(
           if I64.lt_u x 0x10_0000_0000_0000L then to_float x
@@ -947,29 +877,21 @@ module F32CvtOp = struct
   let cvtop (op : Ty.Cvtop.t) (v : Value.t) : Value.t =
     let op' = `Cvtop op in
     match op with
-    | DemoteF64 -> F32.to_value (demote_f64 (F64.of_value 1 op' v))
-    | ConvertSI32 -> F32.to_value (convert_i32_s (Bitv.i32_of_value 1 op' v))
-    | ConvertUI32 -> F32.to_value (convert_i32_u (Bitv.i32_of_value 1 op' v))
-    | ConvertSI64 -> F32.to_value (convert_i64_s (Bitv.i64_of_value 1 op' v))
-    | ConvertUI64 -> F32.to_value (convert_i64_u (Bitv.i64_of_value 1 op' v))
-    | Reinterpret_int -> F32.to_value (Bitv.i32_of_value 1 op' v)
-    | PromoteF32 ->
-      raise
-        (TypeError
-           { index = 1
-           ; value = v
-           ; ty = Ty_fp 32
-           ; op = `Cvtop PromoteF32
-           ; msg = "F64 must promote a F32"
-           } )
+    | DemoteF64 -> to_fp32 (demote_f64 (of_fp64 1 op' v))
+    | ConvertSI32 -> to_fp32 (convert_i32_s (int32_of_bitv 1 op' v))
+    | ConvertUI32 -> to_fp32 (convert_i32_u (int32_of_bitv 1 op' v))
+    | ConvertSI64 -> to_fp32 (convert_i64_s (int64_of_bitv 1 op' v))
+    | ConvertUI64 -> to_fp32 (convert_i64_u (int64_of_bitv 1 op' v))
+    | Reinterpret_int -> to_fp32 (int32_of_bitv 1 op' v)
+    | PromoteF32 -> type_error 1 v (Ty_fp 32) op' "F64 must promote F32"
     | ToString | OfString | _ ->
-      Fmt.failwith {|cvtop: Unsupported f32 operator "%a"|} Ty.Cvtop.pp op
+      eval_error (`Unsupported_operator (op', Ty_fp 32))
 end
 
 module F64CvtOp = struct
   let promote_f32 x =
-    let xf = F32.to_float x in
-    if Float.Infix.(xf = xf) then F64.of_float xf
+    let xf = Int32.float_of_bits x in
+    if Float.Infix.(xf = xf) then Int64.bits_of_float xf
     else
       let nan32bits = I64CvtOp.extend_i32_u x in
       let sign_field =
@@ -981,7 +903,7 @@ module F64CvtOp = struct
       let fields = Int64.logor sign_field significand_field in
       Int64.logor 0x7ff8_0000_0000_0000L fields
 
-  let convert_i32_s x = F64.of_float (Int32.to_float x)
+  let convert_i32_s x = Int64.bits_of_float (Int32.to_float x)
 
   (*
    * Unlike the other convert_u functions, the high half of the i32 range is
@@ -989,9 +911,10 @@ module F64CvtOp = struct
    * shift. Instead, we can use int64 signed arithmetic.
    *)
   let convert_i32_u x =
-    F64.of_float Int64.(to_float (logand (of_int32 x) 0x0000_0000_ffff_ffffL))
+    Int64.bits_of_float
+      Int64.(to_float (logand (of_int32 x) 0x0000_0000_ffff_ffffL))
 
-  let convert_i64_s x = F64.of_float (Int64.to_float x)
+  let convert_i64_s x = Int64.bits_of_float (Int64.to_float x)
 
   (*
    * Values in the low half of the int64 range can be converted with a signed
@@ -1000,7 +923,7 @@ module F64CvtOp = struct
    * bit to round correctly, do a conversion, and then scale it back up.
    *)
   let convert_i64_u (x : int64) =
-    F64.of_float
+    Int64.bits_of_float
       Int64.(
         Int64.Infix.(
           if x >= 0L then to_float x
@@ -1009,23 +932,15 @@ module F64CvtOp = struct
   let cvtop (op : Ty.Cvtop.t) v : Value.t =
     let op' = `Cvtop op in
     match op with
-    | PromoteF32 -> F64.to_value (promote_f32 (F32.of_value 1 op' v))
-    | ConvertSI32 -> F64.to_value (convert_i32_s (Bitv.i32_of_value 1 op' v))
-    | ConvertUI32 -> F64.to_value (convert_i32_u (Bitv.i32_of_value 1 op' v))
-    | ConvertSI64 -> F64.to_value (convert_i64_s (Bitv.i64_of_value 1 op' v))
-    | ConvertUI64 -> F64.to_value (convert_i64_u (Bitv.i64_of_value 1 op' v))
-    | Reinterpret_int -> F64.to_value (Bitv.i64_of_value 1 op' v)
-    | DemoteF64 ->
-      raise
-        (TypeError
-           { index = 1
-           ; value = v
-           ; ty = Ty_bitv 64
-           ; op = `Cvtop DemoteF64
-           ; msg = "F32 must demote a F64"
-           } )
+    | PromoteF32 -> to_fp64 (promote_f32 (of_fp32 1 op' v))
+    | ConvertSI32 -> to_fp64 (convert_i32_s (int32_of_bitv 1 op' v))
+    | ConvertUI32 -> to_fp64 (convert_i32_u (int32_of_bitv 1 op' v))
+    | ConvertSI64 -> to_fp64 (convert_i64_s (int64_of_bitv 1 op' v))
+    | ConvertUI64 -> to_fp64 (convert_i64_u (int64_of_bitv 1 op' v))
+    | Reinterpret_int -> to_fp64 (int64_of_bitv 1 op' v)
+    | DemoteF64 -> type_error 1 v (Ty_fp 64) op' "F32 must demote a F64"
     | ToString | OfString | _ ->
-      Fmt.failwith {|cvtop: Unsupported f64 operator "%a"|} Ty.Cvtop.pp op
+      eval_error (`Unsupported_operator (op', Ty_fp 64))
 end
 
 (* Dispatch *)
@@ -1041,7 +956,7 @@ let op int real bool str lst bv f32 f64 ty op =
   | Ty_fp 32 -> f32 op
   | Ty_fp 64 -> f64 op
   | Ty_fp _ | Ty_app | Ty_unit | Ty_none | Ty_regexp | Ty_roundingMode ->
-    assert false
+    eval_error (`Unsupported_theory ty)
 [@@inline]
 
 let unop =
@@ -1055,7 +970,7 @@ let triop = function
   | Ty.Ty_bool -> Bool.triop
   | Ty_str -> Str.triop
   | Ty_list -> Lst.triop
-  | _ -> assert false
+  | ty -> eval_error (`Unsupported_theory ty)
 
 let relop = function
   | Ty.Ty_int -> Int.relop
@@ -1065,7 +980,7 @@ let relop = function
   | Ty_bitv _ -> Bitv.relop
   | Ty_fp 32 -> F32.relop
   | Ty_fp 64 -> F64.relop
-  | _ -> assert false
+  | ty -> eval_error (`Unsupported_theory ty)
 
 let cvtop = function
   | Ty.Ty_int -> Int.cvtop
@@ -1075,10 +990,10 @@ let cvtop = function
   | Ty_bitv 64 -> I64CvtOp.cvtop
   | Ty_fp 32 -> F32CvtOp.cvtop
   | Ty_fp 64 -> F64CvtOp.cvtop
-  | _ -> assert false
+  | ty -> eval_error (`Unsupported_theory ty)
 
 let naryop = function
   | Ty.Ty_bool -> Bool.naryop
   | Ty_str -> Str.naryop
   | Ty_list -> Lst.naryop
-  | _ -> assert false
+  | ty -> eval_error (`Unsupported_theory ty)

--- a/src/smtml/eval.mli
+++ b/src/smtml/eval.mli
@@ -21,34 +21,37 @@ type op_type =
 
 (** {1 Exceptions} *)
 
-(** Exception raised when a division by zero occurs during evaluation. *)
-exception DivideByZero
-(* FIXME: use snake case instead *)
+(** Context payload for type errors *)
+type type_error_info =
+  { index : int  (** The position of the erroneous value. *)
+  ; value : Value.t  (** The actual value that caused the error. *)
+  ; ty : Ty.t  (** The expected type. *)
+  ; op : op_type  (** The operation that led to the error. *)
+  ; msg : string
+  }
 
-exception Conversion_to_integer
+(** Classification of errors that can occur during evaluation. *)
+type error_kind =
+  [ `Divide_by_zero
+  | `Conversion_to_integer
+  | `Integer_overflow
+  | `Index_out_of_bounds
+  | `Invalid_format_conversion
+  | `Unsupported_operator of op_type * Ty.t
+  | `Unsupported_theory of Ty.t
+  | `Type_error of type_error_info
+  ]
 
-exception Integer_overflow
-
-exception Index_out_of_bounds
+(** Exception raised when an error occurs during concrete evaluation. *)
+exception Eval_error of error_kind
 
 (** Exception raised when an invalid value is encountered during evaluation. *)
 exception Value of Ty.t
 
-(** Exception raised when a type error occurs during evaluation. *)
-exception
-  TypeError of
-    { index : int  (** The position of the erroneous value in the operation. *)
-    ; value : Value.t  (** The actual value that caused the error. *)
-    ; ty : Ty.t  (** The expected type. *)
-    ; op : op_type  (** The operation that led to the error. *)
-    ; msg : string
-    }
-(* FIXME: use snake case instead *)
-
 (** {1 Evaluation Functions} *)
 
 (** [unop ty op v] applies a unary operation [op] on the value [v] of type [ty].
-    Raises [TypeError] if the value does not match the expected type. *)
+    Raises [Type_error] if the value does not match the expected type. *)
 val unop : Ty.t -> Ty.Unop.t -> Value.t -> Value.t
 
 (** [binop ty op v1 v2] applies a binary operation [op] on the values [v1] and

--- a/test/unit/test_eval.ml
+++ b/test/unit/test_eval.ml
@@ -32,13 +32,7 @@ let assert_type_error f =
   try
     f ();
     assert_bool "raise TypeError" false
-  with Eval.TypeError _ -> ()
-
-let assert_parse_error f =
-  try
-    f ();
-    assert_bool "raise Invalid_argument" false
-  with Invalid_argument _ -> ()
+  with Eval.Eval_error (`Type_error _) -> ()
 
 module Int_test = struct
   (* Unary operators *)
@@ -305,7 +299,7 @@ module Real_test = struct
       assert_equal (str "42.") result
     in
     let test_of_string_error _ =
-      assert_parse_error @@ fun () ->
+      assert_raises (Eval.Eval_error `Invalid_format_conversion) @@ fun () ->
       let _ = Eval.cvtop Ty_real OfString (str "not_a_real") in
       ()
     in
@@ -406,7 +400,7 @@ module Str_test = struct
         let result = Eval.binop Ty_str At (str "abc") (int 0) in
         assert_equal (str "a") result )
     ; ( "test_index_out_of_bounds_error" >:: fun _ ->
-        assert_raises Eval.Index_out_of_bounds @@ fun () ->
+        assert_raises Eval.(Eval_error `Index_out_of_bounds) @@ fun () ->
         let result = Eval.binop Ty_str At (str "abc") (int 4) in
         assert_equal (str "a") result )
     ; ( "test_string_prefix" >:: fun _ ->
@@ -469,7 +463,7 @@ module Str_test = struct
         let result = Eval.cvtop Ty_str String_to_int (str "98") in
         assert_equal (int 98) result )
     ; ( "test_string_to_int_raises" >:: fun _ ->
-        assert_parse_error @@ fun () ->
+        assert_raises (Eval.Eval_error `Invalid_format_conversion) @@ fun () ->
         let _ = Eval.cvtop Ty_str String_to_int (str "not_an_int") in
         () )
     ; ( "test_string_from_int" >:: fun _ ->
@@ -479,7 +473,7 @@ module Str_test = struct
         let result = Eval.cvtop Ty_str String_to_float (str "98") in
         assert_equal (real 98.) result )
     ; ( "test_string_to_float_raises" >:: fun _ ->
-        assert_parse_error @@ fun () ->
+        assert_raises (Eval.Eval_error `Invalid_format_conversion) @@ fun () ->
         let _ = Eval.cvtop Ty_str String_to_float (str "not_a_real") in
         () )
     ]

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -12,7 +12,7 @@ let pp_op fmt = function
 
 let _with_type_error f =
   try f ()
-  with Eval.TypeError { index; value; ty; op; _ } ->
+  with Eval.Eval_error (`Type_error { index; value; ty; op; _ }) ->
     Fmt.failwith
       "type error: operator %a.%a argument %d got unexpected value %a" Ty.pp ty
       pp_op op index Value.pp value


### PR DESCRIPTION
Previously, during operator evaluation we would raise generic failures for following three reasons:

- A theory was unsupported
- An operator was not supported by a given theory, and
- A failure in the evaluation of an operator

This would make exception handling difficult for apps that need to gracefully handle failures. For this reason, we refactored the above exceptions to instead raise a `Runtime_exception` of type `runtime_exception_kind`.

Additionally, the refactor included:

- Fixing a couple of bugs when raising the `Type_error` exception.
- Adding all the helpers used for value coercion at the top of the file. I think it's more organised this way. Only time will tell.

BREAKING: Exception API changed for the `Eval` module