### PR TITLE
Use fine-grained token to create release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           cargo install git-cliff --locked
 
       - name: Authenticate GitHub CLI
-        run: gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+        run: gh auth login --with-token <<< "${{ secrets.PR_RELEASE_TOKEN }}"
 
       - name: Run release PR script
         run: ./scripts/create-release.sh


### PR DESCRIPTION
This is required because `GITHUB_TOKEN` does not trigger github actions to run. Which in turn, makes the PR unmergable by people that are not repository owners.