### PR TITLE
Reduce allocations in hashconsing hash function

### DIFF
--- a/src/smtml/bitvector.ml
+++ b/src/smtml/bitvector.ml
@@ -25,6 +25,11 @@ let of_int32 v = make (Z.of_int32 v) 32
 
 let of_int64 v = make (Z.of_int64 v) 64
 
+(* Optimized mixer (DJB2 variant). Inlines to simple arithmetic. *)
+let[@inline] combine h v = (h * 33) + v
+
+let hash a = combine (Z.hash a.value) a.width
+
 let equal a b = Z.equal a.value b.value && a.width = b.width
 
 let eqz v = Z.equal Z.zero v.value

--- a/src/smtml/bitvector.mli
+++ b/src/smtml/bitvector.mli
@@ -18,6 +18,8 @@ val to_int64 : t -> Int64.t
 
 val numbits : t -> int
 
+val hash : t -> int
+
 val equal : t -> t -> bool
 
 val compare : t -> t -> int

--- a/src/smtml/symbol.mli
+++ b/src/smtml/symbol.mli
@@ -86,6 +86,8 @@ val type_of : t -> Ty.t
 
 (** {1 Comparison} *)
 
+val hash : t -> int
+
 (** [compare sym1 sym2] performs a total order comparison of [sym1] and [sym2].
 *)
 val compare : t -> t -> int

--- a/src/smtml/ty.mli
+++ b/src/smtml/ty.mli
@@ -34,6 +34,8 @@ type t =
 
 (** {1 Type Comparison} *)
 
+val hash : t -> int
+
 (** [compare t1 t2] performs a total order comparison of types [t1] and [t2]. *)
 val compare : t -> t -> int
 
@@ -97,6 +99,8 @@ module Unop : sig
     | Regexp_comp  (** Complement. *)
   [@@deriving ord]
 
+  val hash : t -> int
+
   (** [equal op1 op2] checks if unary operations [op1] and [op2] are equal. *)
   val equal : t -> t -> bool
 
@@ -149,6 +153,8 @@ module Binop : sig
     | Regexp_diff  (** Difference of regular expressions. *)
   [@@deriving ord]
 
+  val hash : t -> int
+
   (** [equal op1 op2] checks if binary operations [op1] and [op2] are equal. *)
   val equal : t -> t -> bool
 
@@ -173,6 +179,8 @@ module Relop : sig
     | Ge  (** Greater than or equal. *)
     | GeU  (** Unsigned greater than or equal. *)
   [@@deriving ord]
+
+  val hash : t -> int
 
   (** [equal op1 op2] checks if relational operations [op1] and [op2] are equal.
   *)
@@ -206,6 +214,8 @@ module Triop : sig
       (** Replace all occurrences using a regular expression.
           (str.replace_re_all String RegLan String) *)
   [@@deriving ord]
+
+  val hash : t -> int
 
   (** [equal op1 op2] checks if ternary operations [op1] and [op2] are equal. *)
   val equal : t -> t -> bool
@@ -254,6 +264,8 @@ module Cvtop : sig
     | String_to_re  (** Convert string to regular expression. *)
   [@@deriving ord]
 
+  val hash : t -> int
+
   (** [equal op1 op2] checks if conversion operations [op1] and [op2] are equal.
   *)
   val equal : t -> t -> bool
@@ -273,6 +285,8 @@ module Naryop : sig
     | Concat  (** Concatenation. *)
     | Regexp_union  (** Union of regular expressions. *)
   [@@deriving ord]
+
+  val hash : t -> int
 
   (** [equal op1 op2] checks if n-ary operations [op1] and [op2] are equal. *)
   val equal : t -> t -> bool

--- a/src/smtml/value.mli
+++ b/src/smtml/value.mli
@@ -29,6 +29,8 @@ val type_of : t -> Ty.t
 
 (** {1 Comparison} *)
 
+val hash : t -> int
+
 (** [compare v1 v2] provides a total ordering over values of type [t]. It
     returns a negative integer if [v1] is less than [v2], zero if they are
     equal, and a positive integer if [v1] is greater than [v2]. *)


### PR DESCRIPTION
Seems to improve performance a bit. Not sure if it is just by not using tuples or because of the hash functions of the other modules.