### PR TITLE
improves hashing

### DIFF
--- a/src/smtml/binder.ml
+++ b/src/smtml/binder.ml
@@ -10,6 +10,8 @@ let equal a b =
   | Forall, Forall | Exists, Exists | Let_in, Let_in -> true
   | (Forall | Exists | Let_in), _ -> false
 
+let hash = function Forall -> 0 | Exists -> 1 | Let_in -> 2
+
 let pp fmt = function
   | Forall -> Fmt.string fmt "forall"
   | Exists -> Fmt.string fmt "exists"

--- a/src/smtml/binder.mli
+++ b/src/smtml/binder.mli
@@ -21,6 +21,9 @@ type t =
     and [q2] are equal. *)
 val equal : t -> t -> bool
 
+(** An unseeded hash function. *)
+val hash : t -> int
+
 (** {1 Pretty Printing} *)
 
 (** Pretty-printer for quantifiers and let-bindings. Formats a value of type [t]

--- a/src/smtml/expr.ml
+++ b/src/smtml/expr.ml
@@ -109,7 +109,7 @@ module Expr = struct
       combine h lo
     | Concat (e1, e2) -> combine e1.tag e2.tag
     | Binder (b, vars, e) ->
-      let h = Hashtbl.hash b in
+      let h = Binder.hash b in
       let h_vars = List.fold_left (fun acc x -> combine acc x.Hc.tag) h vars in
       combine h_vars e.tag
 end

--- a/src/smtml/num.ml
+++ b/src/smtml/num.ml
@@ -15,6 +15,13 @@ type printer =
 let type_of (n : t) =
   match n with F32 _ -> Ty.(Ty_fp 32) | F64 _ -> Ty.(Ty_fp 64)
 
+(* Optimized mixer (DJB2 variant). Inlines to simple arithmetic. *)
+let[@inline] combine h v = (h * 33) + v
+
+let hash = function
+  | F32 n -> combine 1 (Int32.hash n)
+  | F64 n -> combine 2 (Int64.hash n)
+
 let compare n1 n2 =
   match (n1, n2) with
   | F32 i1, F32 i2 ->

--- a/src/smtml/num.mli
+++ b/src/smtml/num.mli
@@ -33,6 +33,9 @@ val compare : t -> t -> int
 *)
 val equal : t -> t -> bool
 
+(* An unseeded hash function. *)
+val hash : t -> int
+
 (** {1 Pretty Printing} *)
 
 (** [set_default_printer p] sets the default printer format for displaying

--- a/src/smtml/symbol.ml
+++ b/src/smtml/symbol.ml
@@ -49,13 +49,11 @@ let[@inline] combine h v = (h * 33) + v
 
 let hash_name n =
   match n with
-  | Simple s ->
-    (* Hashtbl.hash is fine for strings (it's a C primitive) *)
-    combine 0 (Hashtbl.hash s)
+  | Simple s -> combine 0 (String.hash s)
   | Indexed { basename; indices } ->
-    let h = combine 1 (Hashtbl.hash basename) in
+    let h = combine 1 (String.hash basename) in
     (* Fold over indices to avoid list allocation *)
-    List.fold_left (fun acc s -> combine acc (Hashtbl.hash s)) h indices
+    List.fold_left (fun acc s -> combine acc (String.hash s)) h indices
 
 let hash { ty; name; namespace } =
   let h = Ty.hash ty in

--- a/src/smtml/value.ml
+++ b/src/smtml/value.ml
@@ -52,13 +52,13 @@ let rec hash v =
   | False -> 2
   | Unit -> 3
   | Int i -> combine 4 i
-  | Real f -> combine 5 (Hashtbl.hash f)
-  | Str s -> combine 6 (Hashtbl.hash s)
-  | Num n -> combine 7 (Hashtbl.hash n)
+  | Real f -> combine 5 (Float.hash f)
+  | Str s -> combine 6 (String.hash s)
+  | Num n -> combine 7 (Num.hash n)
   | Bitv b -> combine 8 (Bitvector.hash b)
   | List l -> List.fold_left (fun acc v -> combine acc (hash v)) 9 l
   | App (`Op s, args) ->
-    let h = combine 10 (Hashtbl.hash s) in
+    let h = combine 10 (String.hash s) in
     List.fold_left (fun acc v -> combine acc (hash v)) h args
   | Nothing -> 11
   | App _ -> assert false


### PR DESCRIPTION
This is pretty minor, but calling `String.hash` is a little bit better than `Hashtbl.hash` as it calls `"caml_string_hash"` directly, instead of `"caml_hash"`.