### PR TITLE
Remove test that fails with cmdliner 2.1.0

### DIFF
--- a/test/cli/smt2/test_smt2.t
+++ b/test/cli/smt2/test_smt2.t
@@ -1,10 +1,3 @@
-Test parsing a nonexistent file:
-  $ smtml run idontexist.smt2
-  smtml: FILES… arguments: no 'idontexist.smt2' file or directory
-  Usage: smtml run [OPTION]… [FILES]…
-  Try 'smtml run --help' or 'smtml --help' for more information.
-  [124]
-
 Test parsing an empty file:
   $ smtml run test_empty.smt2
 


### PR DESCRIPTION
It's not really that relavent tbh. Our focus in more on the library as well.