### PR TITLE
test: make bisec_ppx a dev dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Install Dependencies
-        run: opam install -y . --deps-only --with-doc --with-test
+        run: opam install -y . --deps-only --with-doc --with-dev-setup
 
       - name: Build doc
         run: opam exec -- dune build @doc

--- a/dune-project
+++ b/dune-project
@@ -90,11 +90,11 @@
   (odoc :with-doc)
   (sherlodoc :with-doc)
   ;; Test dependencies
+  (ounit2 :with-test)
   (bisect_ppx
    (and
-    :with-test
+    :with-dev-setup
     (>= "2.5.0")))
-  (ounit2 :with-test)
   ;; Dev dependencies
   (ocamlformat :with-dev-setup)
   (ocaml-lsp-server :with-dev-setup)

--- a/smtml.opam
+++ b/smtml.opam
@@ -40,8 +40,8 @@ depends: [
   "zarith" {>= "1.5"}
   "odoc" {with-doc}
   "sherlodoc" {with-doc}
-  "bisect_ppx" {with-test & >= "2.5.0"}
   "ounit2" {with-test}
+  "bisect_ppx" {with-dev-setup & >= "2.5.0"}
   "ocamlformat" {with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
   "benchpress" {with-dev-setup & = "dev"}


### PR DESCRIPTION
It's not actually needed to run the tests and it makes the CI in opam-repo skip the tests because it cannot install bisec_ppx.