### PR TITLE
Query extraction to SMT files

### DIFF
--- a/src/bin/cli.ml
+++ b/src/bin/cli.ml
@@ -132,7 +132,8 @@ let commands =
     in
     let default = Term.(ret (const (`Help (`Plain, None)))) in
     Cmd.group info ~default
-      Cmd_smtzilla.[ extract_cmd; regression_cmd; train_cmd ]
+      Cmd_smtzilla.
+        [ extract_features_cmd; extract_queries_cmd; regression_cmd; train_cmd ]
   in
 
   let info = Cmd.info ~version "smtml" in

--- a/src/bin/cmd_smtzilla.ml
+++ b/src/bin/cmd_smtzilla.ml
@@ -154,6 +154,26 @@ let set_debug debug =
   if debug then Logs.Src.set_level Smtml.Log.src (Some Logs.Debug);
   Logs.set_reporter @@ Logs.format_reporter ()
 
+(* TODO: Ideally, trivial queries should not arrive to the solver at all, but
+doing so properly, while taking into account assertions added with `add` would
+require more effort. *)
+let are_trivial = function
+  | [] -> true
+  | [ a ] -> begin
+    (* When there is only one assert, which is a relop between a symbol and a
+    const, or a unop on a symbol or const, the query is considered as trivial.
+    *)
+    match Expr.view a with
+    | Val (False | True)
+    | Relop
+        (_, _, { node = Val _ | Symbol _; _ }, { node = Val _ | Symbol _; _ })
+      ->
+      true
+    | Unop (_, _, { node = Val _ | Symbol _; _ }) -> true
+    | _ -> false
+  end
+  | _ -> false
+
 (* type annotation because otherwise the typechecker thinks ?status is ~status *)
 let rec extract_queries
   (smt2pp :
@@ -163,6 +183,8 @@ let rec extract_queries
     -> Expr.t list Fmt.t ) destdir seen cnt l =
   match l with
   | [] -> Ok (seen, cnt)
+  | (_, assertions, _, _, _) :: t when are_trivial assertions ->
+    extract_queries smt2pp destdir seen cnt t
   | (_, assertions, _, _, status) :: t ->
     (* TODO: do better than Hashtbl.hash *)
     let hash = Hashtbl.hash assertions in
@@ -193,7 +215,7 @@ let extract_queries (path : Fpath.t) (destdir : Fpath.t) =
       (fun ic seen ->
         try queries_from_ic smt2pp destdir seen 1 ic >>| fun _ -> ()
         with End_of_file ->
-          Log.debug (fun k -> k "Finished reading results@.");
+          Log.debug (fun k -> k "Finished extracting queries@.");
           Ok () )
       IntSet.empty
   in

--- a/src/bin/cmd_smtzilla.ml
+++ b/src/bin/cmd_smtzilla.ml
@@ -1,6 +1,8 @@
 open Cmdliner
 open Term.Syntax
 open Rresult
+open Smtml
+module IntSet = Set.Make (Int)
 
 let script_name = R.failwith_error_msg (Fpath.of_string "smtzilla.py")
 
@@ -42,6 +44,15 @@ let csv_file_exists_conv =
     else Fmt.error_msg "File '%a' is not a CSV file" Fpath.pp path
   in
   Arg.conv (parse_csv_file, Fpath.pp)
+
+let dir_exists_conv =
+  let parse s =
+    Fpath.of_string s >>= fun path ->
+    Bos.OS.Dir.exists path >>= fun b ->
+    if b then Ok path
+    else Fmt.error_msg "The directory '%a' does not exist" Fpath.pp path
+  in
+  Arg.conv (parse, Fpath.pp)
 
 let existing_parent_dir_conv =
   let parse s =
@@ -113,6 +124,10 @@ let marshalled_file =
   Arg.(
     required & pos 0 (some file_exists_conv) None (info [] ~doc ~docv:"INPUT") )
 
+let dest_dir =
+  let doc = "Path to a directory in which to store the exported queries." in
+  Arg.(required & pos 1 (some dir_exists_conv) None (info [] ~doc ~docv:"DIR"))
+
 let output_csv =
   let doc =
     "Path to the output csv file in which to store the query features."
@@ -138,6 +153,62 @@ let output_json p =
 let set_debug debug =
   if debug then Logs.Src.set_level Smtml.Log.src (Some Logs.Debug);
   Logs.set_reporter @@ Logs.format_reporter ()
+
+let rec extract_queries smt2pp destdir seen cnt l =
+  match l with
+  | [] -> Ok (seen, cnt)
+  | (_, assertions, _, _) :: t ->
+    (* TODO: do better than Hashtbl.hash *)
+    let hash = Hashtbl.hash assertions in
+    if IntSet.mem hash seen then extract_queries smt2pp destdir seen cnt t
+    else
+      let file_path = Fpath.(destdir / Fmt.str "query.%d.smt2" cnt) in
+      let str =
+        Fmt.str "%a" (smt2pp ?name:None ?logic:None ?status:None) assertions
+      in
+      Bos.OS.File.write file_path str >>= fun _ ->
+      extract_queries smt2pp destdir (IntSet.add hash seen) (cnt + 1) t
+
+let rec queries_from_ic smt2pp destdir seen cnt ic =
+  let queries : (string * Expr.t list * bool * int64) list =
+    Marshal.from_channel ic
+  in
+  extract_queries smt2pp destdir seen cnt queries >>= fun (seen, cnt) ->
+  queries_from_ic smt2pp destdir seen cnt ic
+
+let extract_queries (path : Fpath.t) (destdir : Fpath.t) =
+  let (module M) = Solver_type.to_mappings Solver_type.Z3_solver in
+  if not M.is_available then
+    Fmt.failwith "Query extraction to smt file depends on Z3";
+  let smt2pp = M.Smtlib.pp in
+  try
+    let ic = In_channel.open_bin (Fpath.to_string path) in
+    try
+      match queries_from_ic smt2pp destdir IntSet.empty 1 ic with
+      | Ok () -> ()
+      | Error (`Msg msg) -> raise (Failure msg)
+    with End_of_file ->
+      Log.debug (fun k -> k "Finished reading results@.");
+      In_channel.close ic
+  with e ->
+    Fmt.failwith "Failed to extract queries from %a\nBecause %s\n%!" Fpath.pp
+      path (Printexc.to_string e)
+
+let extract_queries_cmd =
+  let extract_info =
+    let doc =
+      "Given a file containing marshalled smtml queries, extracts the (unique) \
+       queries into files in a given folder. The files are named \
+       `query.n.smt2` where `n` is the query's number."
+    in
+    Cmd.info "extract-queries" ~doc
+  in
+  let extract =
+    let+ marshalled_file
+    and+ dest_dir in
+    extract_queries marshalled_file dest_dir
+  in
+  Cmd.v extract_info extract
 
 let run_regression ~debug ~gradient_boost ~n_estimators ~max_depth ~pp_stats
   ~run_simulation ~input_csv ~output_json =
@@ -175,7 +246,7 @@ let run_regression ~debug ~gradient_boost ~n_estimators ~max_depth ~pp_stats
         msg Fpath.pp py_script_path );
     Fmt.failwith "Python script failure"
 
-let extract_cmd =
+let extract_features_cmd =
   let extract_info =
     let doc =
       "Given a file containing marshalled smtml queries, extracts features \

--- a/src/bin/cmd_smtzilla.ml
+++ b/src/bin/cmd_smtzilla.ml
@@ -188,18 +188,20 @@ let extract_queries (path : Fpath.t) (destdir : Fpath.t) =
   if not M.is_available then
     Fmt.failwith "Query extraction to smt file depends on Z3";
   let smt2pp = M.Smtlib.pp in
-  try
-    let ic = In_channel.open_bin (Fpath.to_string path) in
-    try
-      match queries_from_ic smt2pp destdir IntSet.empty 1 ic with
-      | Ok () -> ()
-      | Error (`Msg msg) -> raise (Failure msg)
-    with End_of_file ->
-      Log.debug (fun k -> k "Finished reading results@.");
-      In_channel.close ic
-  with e ->
-    Fmt.failwith "Failed to extract queries from %a\nBecause %s\n%!" Fpath.pp
-      path (Printexc.to_string e)
+  let res =
+    Bos.OS.File.with_ic path
+      (fun ic seen ->
+        try queries_from_ic smt2pp destdir seen 1 ic >>| fun _ -> ()
+        with End_of_file ->
+          Log.debug (fun k -> k "Finished reading results@.");
+          Ok () )
+      IntSet.empty
+  in
+  match Rresult.R.join res with
+  | Ok () -> ()
+  | Error (`Msg msg) ->
+    Fmt.failwith "Failed to extract queries from %a\nBecause of: %s" Fpath.pp
+      path msg
 
 let extract_queries_cmd =
   let extract_info =

--- a/src/bin/cmd_smtzilla.ml
+++ b/src/bin/cmd_smtzilla.ml
@@ -154,23 +154,30 @@ let set_debug debug =
   if debug then Logs.Src.set_level Smtml.Log.src (Some Logs.Debug);
   Logs.set_reporter @@ Logs.format_reporter ()
 
-let rec extract_queries smt2pp destdir seen cnt l =
+(* type annotation because otherwise the typechecker thinks ?status is ~status *)
+let rec extract_queries
+  (smt2pp :
+       ?name:string
+    -> ?logic:Logic.t
+    -> ?status:[ `Sat | `Unknown | `Unsat ]
+    -> Expr.t list Fmt.t ) destdir seen cnt l =
   match l with
   | [] -> Ok (seen, cnt)
-  | (_, assertions, _, _) :: t ->
+  | (_, assertions, _, _, status) :: t ->
     (* TODO: do better than Hashtbl.hash *)
     let hash = Hashtbl.hash assertions in
     if IntSet.mem hash seen then extract_queries smt2pp destdir seen cnt t
     else
       let file_path = Fpath.(destdir / Fmt.str "query.%d.smt2" cnt) in
       let str =
-        Fmt.str "%a" (smt2pp ?name:None ?logic:None ?status:None) assertions
+        Fmt.str "%a" (smt2pp ?name:None ?logic:None ~status) assertions
       in
       Bos.OS.File.write file_path str >>= fun _ ->
       extract_queries smt2pp destdir (IntSet.add hash seen) (cnt + 1) t
 
 let rec queries_from_ic smt2pp destdir seen cnt ic =
-  let queries : (string * Expr.t list * bool * int64) list =
+  let queries :
+    (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ]) list =
     Marshal.from_channel ic
   in
   extract_queries smt2pp destdir seen cnt queries >>= fun (seen, cnt) ->

--- a/src/bin/cmd_smtzilla.ml
+++ b/src/bin/cmd_smtzilla.ml
@@ -169,10 +169,10 @@ let rec extract_queries
     if IntSet.mem hash seen then extract_queries smt2pp destdir seen cnt t
     else
       let file_path = Fpath.(destdir / Fmt.str "query.%d.smt2" cnt) in
-      let str =
-        Fmt.str "%a" (smt2pp ?name:None ?logic:None ~status) assertions
-      in
-      Bos.OS.File.write file_path str >>= fun _ ->
+      Bos.OS.File.writef file_path "%a"
+        (smt2pp ?name:None ?logic:None ~status)
+        assertions
+      >>= fun _ ->
       extract_queries smt2pp destdir (IntSet.add hash seen) (cnt + 1) t
 
 let rec queries_from_ic smt2pp destdir seen cnt ic =

--- a/src/bin/cmd_smtzilla.ml
+++ b/src/bin/cmd_smtzilla.ml
@@ -154,25 +154,33 @@ let set_debug debug =
   if debug then Logs.Src.set_level Smtml.Log.src (Some Logs.Debug);
   Logs.set_reporter @@ Logs.format_reporter ()
 
+let rec is_trivial_assert e =
+  match Expr.view e with
+  | Val _ | Symbol _ -> true
+  | Relop (_, _, { node = Symbol _ | Val _; _ }, { node = Symbol _ | Val _; _ })
+  | Binop (_, _, { node = Symbol _ | Val _; _ }, { node = Symbol _ | Val _; _ })
+    ->
+    true
+  | Binop (_, _, e1, e2) | Relop (_, _, e1, e2) ->
+    is_trivial_assert e1 || is_trivial_assert e2
+  | Cvtop (_, _, e) | Unop (_, _, e) -> is_trivial_assert e
+  | _ -> false
+
 (* TODO: Ideally, trivial queries should not arrive to the solver at all, but
 doing so properly, while taking into account assertions added with `add` would
 require more effort. *)
 let are_trivial = function
   | [] -> true
-  | [ a ] -> begin
+  | [ a ] when is_trivial_assert a ->
     (* When there is only one assert, which is a relop between a symbol and a
     const, or a unop on a symbol or const, the query is considered as trivial.
     *)
-    match Expr.view a with
-    | Val (False | True)
-    | Relop
-        (_, _, { node = Val _ | Symbol _; _ }, { node = Val _ | Symbol _; _ })
-      ->
-      true
-    | Unop (_, _, { node = Val _ | Symbol _; _ }) -> true
-    | _ -> false
-  end
-  | _ -> false
+    true
+  | l when List.length l < 10 && List.for_all is_trivial_assert l ->
+    (* When there are less than 10 asserts (totally arbitrary) and all asserts
+       are trivial  *)
+    true
+  | _l -> false
 
 (* type annotation because otherwise the typechecker thinks ?status is ~status *)
 let rec extract_queries

--- a/src/bin/cmd_smtzilla.ml
+++ b/src/bin/cmd_smtzilla.ml
@@ -191,7 +191,10 @@ let rec extract_queries
     -> Expr.t list Fmt.t ) destdir seen cnt l =
   match l with
   | [] -> Ok (seen, cnt)
-  | (_, assertions, _, _, _) :: t when are_trivial assertions ->
+  | (_, assertions, _, time, _) :: t
+    when time <= 10_000_000L || are_trivial assertions ->
+    (* Time limit to filter out simple tests that are solver in less than
+      0.01 seconds *)
     extract_queries smt2pp destdir seen cnt t
   | (_, assertions, _, _, status) :: t ->
     (* TODO: do better than Hashtbl.hash *)

--- a/src/smtml/expr.ml
+++ b/src/smtml/expr.ml
@@ -114,7 +114,7 @@ module Expr = struct
       combine h_vars e.tag
 end
 
-module Hc = Hc.Make [@inlined hint] (Expr)
+module Hc = Hc.Make_strong [@inlined hint] (Expr)
 
 let equal (hte1 : t) (hte2 : t) = phys_equal hte1 hte2 [@@inline]
 

--- a/src/smtml/feature_extraction.ml
+++ b/src/smtml/feature_extraction.ml
@@ -336,7 +336,7 @@ let extract_feats_aux : Expr.t -> int FeatMap.t =
   in
   let rec visit depth feats (e : Expr.t) =
     let feats = incr_feat feats (string_of_expr_kind e.node (Expr.ty e)) in
-    match e.node with
+    match Expr.view e with
     | Val _ | Symbol _ -> (depth, feats)
     | Ptr { offset; _ } -> visit (depth + 1) feats offset
     | List lst ->

--- a/src/smtml/feature_extraction.ml
+++ b/src/smtml/feature_extraction.ml
@@ -3,6 +3,7 @@
 (* Written by the Smtml programmers *)
 
 open Regression_model
+open Rresult
 
 let string_of_unop (unop : Ty.Unop.t) : string =
   match unop with
@@ -405,28 +406,26 @@ let extract_feats_aux : Expr.t -> int FeatMap.t =
     let depth, feats = visit 1 FeatMap.empty expr in
     FeatMap.add "depth" depth feats
 
-let read_marshalled_file (path : Fpath.t) :
-  (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ]) list =
+let rec read_marshalled_queries results ic : unit =
+  let res :
+    (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ]) list =
+    Marshal.from_channel ic
+  in
+  Log.debug (fun k -> k "Read %d results@." (List.length res));
+  results := List.rev_append res !results;
+  read_marshalled_queries results ic
+
+let read_marshalled_file (path : Fpath.t) =
   let results = ref [] in
-  try
-    let ic = In_channel.open_bin (Fpath.to_string path) in
-    ( try
-        while true do
-          let res :
-            (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ])
-            list =
-            Marshal.from_channel ic
-          in
-          Log.debug (fun k -> k "Read %d results@." (List.length res));
-          results := List.rev_append res !results
-        done
-      with End_of_file -> Log.debug (fun k -> k "Finished reading results@.") );
-    In_channel.close ic;
-    List.rev !results
-  with e ->
-    Fmt.epr "Failed to read %a\nBecause %s\n%!" Fpath.pp path
-      (Printexc.to_string e);
-    []
+  let res =
+    Bos.OS.File.with_ic path
+      (fun ic () ->
+        try read_marshalled_queries results ic
+        with End_of_file ->
+          Log.debug (fun k -> k "Finished reading results@.") )
+      ()
+  in
+  res >>| fun () -> List.rev !results
 
 let extract_feats assertions =
   let feats, depth_acc =
@@ -458,8 +457,8 @@ let extract_feats_wtime assertions runtime =
   FeatMap.add "time" (Int64.to_int runtime) (extract_feats assertions)
 
 let cmd marshalled_file output_csv =
-  let entries = read_marshalled_file marshalled_file in
-  let res : ((unit, [> Rresult.R.msg ]) result, [> Rresult.R.msg ]) result =
+  let res =
+    read_marshalled_file marshalled_file >>| fun entries ->
     Bos.OS.File.with_oc output_csv
       (fun oc entries ->
         Out_channel.output_string oc
@@ -484,6 +483,6 @@ let cmd marshalled_file output_csv =
         Ok () )
       entries
   in
-  match Rresult.R.join res with
+  match Rresult.R.join (Rresult.R.join res) with
   | Error (`Msg m) -> Fmt.failwith "%s" m
   | Ok () -> Log.debug (fun k -> k "Done writing to %a\n%!" Fpath.pp output_csv)

--- a/src/smtml/feature_extraction.ml
+++ b/src/smtml/feature_extraction.ml
@@ -405,10 +405,11 @@ let extract_feats_aux : Expr.t -> int FeatMap.t =
     let depth, feats = visit 1 FeatMap.empty expr in
     FeatMap.add "depth" depth feats
 
-let read_marshalled_file path : (string * Expr.t list * bool * int64) list =
+let read_marshalled_file (path : Fpath.t) :
+  (string * Expr.t list * bool * int64) list =
   let results = ref [] in
   try
-    let ic = In_channel.open_bin path in
+    let ic = In_channel.open_bin (Fpath.to_string path) in
     ( try
         while true do
           let res : (string * Expr.t list * bool * int64) list =
@@ -421,7 +422,8 @@ let read_marshalled_file path : (string * Expr.t list * bool * int64) list =
     In_channel.close ic;
     List.rev !results
   with e ->
-    Fmt.epr "Failed to read %s\nBecause %s\n%!" path (Printexc.to_string e);
+    Fmt.epr "Failed to read %a\nBecause %s\n%!" Fpath.pp path
+      (Printexc.to_string e);
     []
 
 let extract_feats assertions =
@@ -453,8 +455,8 @@ let extract_feats assertions =
 let extract_feats_wtime assertions runtime =
   FeatMap.add "time" (Int64.to_int runtime) (extract_feats assertions)
 
-let cmd directory output_csv =
-  let entries = read_marshalled_file (Fpath.to_string directory) in
+let cmd marshalled_file output_csv =
+  let entries = read_marshalled_file marshalled_file in
   let res : ((unit, [> Rresult.R.msg ]) result, [> Rresult.R.msg ]) result =
     Bos.OS.File.with_oc output_csv
       (fun oc entries ->

--- a/src/smtml/feature_extraction.ml
+++ b/src/smtml/feature_extraction.ml
@@ -406,13 +406,15 @@ let extract_feats_aux : Expr.t -> int FeatMap.t =
     FeatMap.add "depth" depth feats
 
 let read_marshalled_file (path : Fpath.t) :
-  (string * Expr.t list * bool * int64) list =
+  (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ]) list =
   let results = ref [] in
   try
     let ic = In_channel.open_bin (Fpath.to_string path) in
     ( try
         while true do
-          let res : (string * Expr.t list * bool * int64) list =
+          let res :
+            (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ])
+            list =
             Marshal.from_channel ic
           in
           Log.debug (fun k -> k "Read %d results@." (List.length res));
@@ -463,7 +465,7 @@ let cmd marshalled_file output_csv =
         Out_channel.output_string oc
           (String.cat (String.concat "," final_names) "\n");
         List.iter
-          (fun (solver_name, exprs, model, t) ->
+          (fun (solver_name, exprs, model, t, _) ->
             if List.compare_lengths exprs [] > 0 then
               let feats = extract_feats_wtime exprs t in
               let row =

--- a/src/smtml/feature_extraction.mli
+++ b/src/smtml/feature_extraction.mli
@@ -6,7 +6,9 @@ open Regression_model
 
 val read_marshalled_file :
      Fpath.t
-  -> (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ]) list
+  -> ( (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ]) list
+     , Rresult.R.msg )
+     result
 
 val extract_feats : Expr.t list -> features
 

--- a/src/smtml/feature_extraction.mli
+++ b/src/smtml/feature_extraction.mli
@@ -4,7 +4,7 @@
 
 open Regression_model
 
-val read_marshalled_file : string -> (string * Expr.t list * bool * int64) list
+val read_marshalled_file : Fpath.t -> (string * Expr.t list * bool * int64) list
 
 val extract_feats : Expr.t list -> features
 

--- a/src/smtml/feature_extraction.mli
+++ b/src/smtml/feature_extraction.mli
@@ -4,7 +4,9 @@
 
 open Regression_model
 
-val read_marshalled_file : Fpath.t -> (string * Expr.t list * bool * int64) list
+val read_marshalled_file :
+     Fpath.t
+  -> (string * Expr.t list * bool * int64 * [ `Sat | `Unsat | `Unknown ]) list
 
 val extract_feats : Expr.t list -> features
 

--- a/src/smtml/mappings.ml
+++ b/src/smtml/mappings.ml
@@ -934,7 +934,7 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
             s.last_assumptions <- assumptions );
           let ctx, encoded_assuptions = Encoder.encode_exprs ctx assumptions in
           s.last_ctx <- Some ctx;
-          Utils.run_and_log_query ~model:false
+          Utils.check_log_query
             (fun () ->
               M.Solver.check s.solver ~ctx ~assumptions:encoded_assuptions )
             M.Internals.name (List.rev assumptions)
@@ -942,7 +942,7 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
       let model { solver; last_ctx; assumptions; last_assumptions; _ } =
         match last_ctx with
         | Some ctx ->
-          Utils.run_and_log_query ~model:true
+          Utils.model_log_query
             (fun () ->
               M.Solver.model solver |> Option.map (fun m -> { model = m; ctx }) )
             M.Internals.name

--- a/src/smtml/utils.ml
+++ b/src/smtml/utils.ml
@@ -28,9 +28,13 @@ let[@inline never] protect m f =
    all queries sent to the solver (with their timestamps) to the given file *)
 let write =
   match query_log_path with
-  | None -> fun ~model:_ _ _ _ -> ()
+  | None -> fun ~model:_ _ _ _ _ -> ()
   | Some path ->
-    let log_entries : (string * Expr.t list * bool * int64) list ref = ref [] in
+    let log_entries :
+      (string * Expr.t list * bool * int64 * [ `Sat | `Unknown | `Unsat ]) list
+      ref =
+      ref []
+    in
     let close () =
       if List.compare_length_with !log_entries 0 <> 0 then
         try
@@ -50,16 +54,30 @@ let write =
     Sys.set_signal Sys.sigterm (Sys.Signal_handle (fun _ -> close ()));
     (* write *)
     let mutex = Mutex.create () in
-    fun ~model solver_name assumptions time ->
-      let entry = (solver_name, assumptions, model, time) in
+    fun ~model solver_name assumptions time status ->
+      let entry = (solver_name, assumptions, model, time, status) in
       protect mutex (fun () -> log_entries := entry :: !log_entries)
 
-let run_and_log_query ~model f name assumptions =
+let check_log_query (f : unit -> [ `Sat | `Unknown | `Unsat ]) name assumptions
+    =
   match query_log_path with
   | Some _ ->
     let counter = Mtime_clock.counter () in
     let res = f () in
-    write ~model name assumptions
-      (Mtime.Span.to_uint64_ns (Mtime_clock.count counter));
+    write ~model:false name assumptions
+      (Mtime.Span.to_uint64_ns (Mtime_clock.count counter))
+      res;
+    res
+  | None -> f ()
+
+let model_log_query f name assumptions =
+  match query_log_path with
+  | Some _ ->
+    let counter = Mtime_clock.counter () in
+    let res = f () in
+    (* TODO: can no model actually mean `Unsat? *)
+    write ~model:true name assumptions
+      (Mtime.Span.to_uint64_ns (Mtime_clock.count counter))
+      (if Option.is_some res then `Sat else `Unknown);
     res
   | None -> f ()


### PR DESCRIPTION
And added `status` (expected result) to the logged SMT queries (so that we can show it in the extracted files)

(EDIT: ~~marked as draft because ` Bos.OS.File.write` seems to segfault with large strings, I'll try to do that in a safer way~~, the issue was actually somewhere else, it seems to have been fixed by replacing `HC.Make` with `HC.Make_strong`, thanks @redianthus)