### PR TITLE
Explicitly depend on rresult

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -82,6 +82,7 @@
   ppx_enumerate
   (prelude
    (>= "0.5"))
+  rresult
   (scfg
    (>= "0.5"))
   (mtime

--- a/smtml.opam
+++ b/smtml.opam
@@ -36,6 +36,7 @@ depends: [
   "ppx_deriving"
   "ppx_enumerate"
   "prelude" {>= "0.5"}
+  "rresult"
   "scfg" {>= "0.5"}
   "mtime" {>= "2.0.0"}
   "yojson" {>= "1.6.0"}

--- a/src/smtml/dune
+++ b/src/smtml/dune
@@ -71,6 +71,7 @@
   menhirLib
   ocaml_intrinsics
   ppx_enumerate
+  rresult
   scfg
   smtml.prelude
   smtml.smtzilla_utils


### PR DESCRIPTION
The file `src/smtml/feature_extraction.mli` refers to the module `Rresult` but does not explicitly link to it.

IIUC, the `Rresult` module is made available through the `bos` library (at version 0.2) but this no longer works with `bos` 0.3.0.