### PR TITLE
Implies binop

### DIFF
--- a/src/smtml/eval.ml
+++ b/src/smtml/eval.ml
@@ -288,6 +288,7 @@ module Bool = struct
     | And -> to_bool (a && b)
     | Or -> to_bool (a || b)
     | Xor -> to_bool (xor a b)
+    | Implies -> to_bool ( not a || b)
     | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_bool))
 
   let[@inline] triop (op : Ty.Triop.t) c v1 v2 =

--- a/src/smtml/eval.ml
+++ b/src/smtml/eval.ml
@@ -288,7 +288,7 @@ module Bool = struct
     | And -> to_bool (a && b)
     | Or -> to_bool (a || b)
     | Xor -> to_bool (xor a b)
-    | Implies -> to_bool ( not a || b)
+    | Implies -> to_bool ((not a) || b)
     | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_bool))
 
   let[@inline] triop (op : Ty.Triop.t) c v1 v2 =

--- a/test/unit/test_eval.ml
+++ b/test/unit/test_eval.ml
@@ -347,6 +347,12 @@ module Bool_test = struct
         assert_equal true_ (Eval.binop Ty_bool Xor true_ false_);
         assert_equal true_ (Eval.binop Ty_bool Xor false_ true_);
         assert_equal false_ (Eval.binop Ty_bool Xor false_ false_) )
+    ; (
+        "test_implies" >:: fun _ ->
+        assert_equal true_ (Eval.binop Ty_bool Implies true_ true_);
+        assert_equal false_ (Eval.binop Ty_bool Implies true_ false_);
+        assert_equal true_ (Eval.binop Ty_bool Implies false_ true_);
+        assert_equal true_ (Eval.binop Ty_bool Implies false_ false_) )
     ]
 
   let triop =

--- a/test/unit/test_eval.ml
+++ b/test/unit/test_eval.ml
@@ -347,8 +347,7 @@ module Bool_test = struct
         assert_equal true_ (Eval.binop Ty_bool Xor true_ false_);
         assert_equal true_ (Eval.binop Ty_bool Xor false_ true_);
         assert_equal false_ (Eval.binop Ty_bool Xor false_ false_) )
-    ; (
-        "test_implies" >:: fun _ ->
+    ; ( "test_implies" >:: fun _ ->
         assert_equal true_ (Eval.binop Ty_bool Implies true_ true_);
         assert_equal false_ (Eval.binop Ty_bool Implies true_ false_);
         assert_equal true_ (Eval.binop Ty_bool Implies false_ true_);


### PR DESCRIPTION
```ocaml
let expr = Smtml.Expr.Bool.implies Smtml.Expr.Bool.false_ Smtml.Expr.Bool.false_

module Z3 = Smtml.Solver.Batch (Smtml.Z3_mappings)

let solver = Z3.create ()

let () =
  match Z3.check solver [ expr ] with
  | `Sat -> Format.printf "SAT@\n"
  | `Unsat -> Format.printf "UNSAT@\n"
  | `Unknown -> Format.printf "UNKNOWN@\n"
```

For the following example an exception is thrown.
