### PR TITLE
Add indexed rotate operators

### DIFF
--- a/src/smtml/bitwuzla_mappings.default.ml
+++ b/src/smtml/bitwuzla_mappings.default.ml
@@ -365,9 +365,17 @@ module Fresh_bitwuzla (B : Bitwuzla_cxx.S) : M = struct
 
     let rem_u t1 t2 = mk_term2 Kind.Bv_urem t1 t2
 
-    let rotate_left t1 t2 = mk_term2 Kind.Bv_rol t1 t2
+    let rotate_left n t =
+      let bitwidth = Sort.bv_size (Term.sort t) in
+      mk_term2 Kind.Bv_rol t (of_z (Z.of_int n) bitwidth)
 
-    let rotate_right t1 t2 = mk_term2 Kind.Bv_ror t1 t2
+    let rotate_right n t =
+      let bitwidth = Sort.bv_size (Term.sort t) in
+      mk_term2 Kind.Bv_ror t (of_z (Z.of_int n) bitwidth)
+
+    let ext_rotate_left t1 t2 = mk_term2 Kind.Bv_rol t1 t2
+
+    let ext_rotate_right t1 t2 = mk_term2 Kind.Bv_ror t1 t2
 
     let nego t = mk_term1 Kind.Bv_nego t
 

--- a/src/smtml/cvc5_mappings.default.ml
+++ b/src/smtml/cvc5_mappings.default.ml
@@ -305,11 +305,21 @@ module Fresh_cvc5 () = struct
 
     let rem_u t1 t2 = Term.mk_term tm Kind.Bitvector_urem [| t1; t2 |]
 
-    let rotate_left t1 t2 =
-      Term.mk_term tm Kind.Bitvector_rotate_left [| t1; t2 |]
+    let rotate_left n t =
+      let op = Op.mk_op tm Kind.Bitvector_rotate_left [| n |] in
+      Term.mk_term_op tm op [| t |]
 
-    let rotate_right t1 t2 =
-      Term.mk_term tm Kind.Bitvector_rotate_right [| t1; t2 |]
+    let rotate_right n t =
+      let op = Op.mk_op tm Kind.Bitvector_rotate_right [| n |] in
+      Term.mk_term_op tm op [| t |]
+
+    let ext_rotate_left _ _ =
+      Fmt.failwith "%s:%d: %s not implemented. Use 'rotate_left' instead"
+        __MODULE__ __LINE__ __FUNCTION__
+
+    let ext_rotate_right _ _ =
+      Fmt.failwith "%s:%d: %s not implemented. Use 'rotate_right' instead"
+        __MODULE__ __LINE__ __FUNCTION__
 
     let nego _ =
       Fmt.failwith "%s:%d: %s not implemented" __MODULE__ __LINE__ __FUNCTION__

--- a/src/smtml/dolmenexpr_to_expr.ml
+++ b/src/smtml/dolmenexpr_to_expr.ml
@@ -338,9 +338,13 @@ module DolmenIntf = struct
 
     let rem_u = DTerm.Bitv.urem
 
-    let rotate_left t1 t2 = DTerm.Bitv.rotate_left (int_of_term t2) t1
+    let rotate_left n t = DTerm.Bitv.rotate_left n t
 
-    let rotate_right t1 t2 = DTerm.Bitv.rotate_right (int_of_term t2) t1
+    let rotate_right n t = DTerm.Bitv.rotate_right n t
+
+    let ext_rotate_left t1 t2 = DTerm.Bitv.rotate_left (int_of_term t2) t1
+
+    let ext_rotate_right t1 t2 = DTerm.Bitv.rotate_right (int_of_term t2) t1
 
     let nego _ =
       Fmt.failwith "%s:%d: %s not implemented" __MODULE__ __LINE__ __FUNCTION__

--- a/src/smtml/dolmenexpr_to_expr.mli
+++ b/src/smtml/dolmenexpr_to_expr.mli
@@ -287,9 +287,13 @@ module DolmenIntf : sig
 
     val rem_u : term -> term -> term
 
-    val rotate_left : term -> term -> term
+    val rotate_left : int -> term -> term
 
-    val rotate_right : term -> term -> term
+    val rotate_right : int -> term -> term
+
+    val ext_rotate_left : term -> term -> term
+
+    val ext_rotate_right : term -> term -> term
 
     val nego : term -> term
 

--- a/src/smtml/eval.ml
+++ b/src/smtml/eval.ml
@@ -528,6 +528,12 @@ module Bitv = struct
     | Clz -> to_bitv (Bitvector.clz bv)
     | Ctz -> to_bitv (Bitvector.ctz bv)
     | Popcnt -> to_bitv (Bitvector.popcnt bv)
+    | Rotl n ->
+      let shift_count = Bitvector.make (Z.of_int n) (Bitvector.numbits bv) in
+      to_bitv (Bitvector.rotate_left bv shift_count)
+    | Rotr n ->
+      let shift_count = Bitvector.make (Z.of_int n) (Bitvector.numbits bv) in
+      to_bitv (Bitvector.rotate_right bv shift_count)
     | _ ->
       eval_error
         (`Unsupported_operator (`Unop op, Ty_bitv (Bitvector.numbits bv)))
@@ -549,8 +555,8 @@ module Bitv = struct
     | Shl -> to_bitv (Bitvector.shl bv1 bv2)
     | ShrL -> to_bitv (Bitvector.lshr bv1 bv2)
     | ShrA -> to_bitv (Bitvector.ashr bv1 bv2)
-    | Rotl -> to_bitv (Bitvector.rotate_left bv1 bv2)
-    | Rotr -> to_bitv (Bitvector.rotate_right bv1 bv2)
+    | Ext_rotl -> to_bitv (Bitvector.rotate_left bv1 bv2)
+    | Ext_rotr -> to_bitv (Bitvector.rotate_right bv1 bv2)
     | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_bitv 0))
 
   let[@inline] relop op bv1 bv2 =

--- a/src/smtml/eval.ml
+++ b/src/smtml/eval.ml
@@ -522,6 +522,12 @@ module Bitv = struct
     | Clz -> to_bitv (Bitvector.clz bv)
     | Ctz -> to_bitv (Bitvector.ctz bv)
     | Popcnt -> to_bitv (Bitvector.popcnt bv)
+    | Rotl n ->
+      let shift_count = Bitvector.make (Z.of_int n) (Bitvector.numbits bv) in
+      to_bitv (Bitvector.rotate_left bv shift_count)
+    | Rotr n ->
+      let shift_count = Bitvector.make (Z.of_int n) (Bitvector.numbits bv) in
+      to_bitv (Bitvector.rotate_right bv shift_count)
     | _ ->
       eval_error
         (`Unsupported_operator (`Unop op, Ty_bitv (Bitvector.numbits bv)))
@@ -543,8 +549,8 @@ module Bitv = struct
     | Shl -> to_bitv (Bitvector.shl bv1 bv2)
     | ShrL -> to_bitv (Bitvector.lshr bv1 bv2)
     | ShrA -> to_bitv (Bitvector.ashr bv1 bv2)
-    | Rotl -> to_bitv (Bitvector.rotate_left bv1 bv2)
-    | Rotr -> to_bitv (Bitvector.rotate_right bv1 bv2)
+    | Ext_rotl -> to_bitv (Bitvector.rotate_left bv1 bv2)
+    | Ext_rotr -> to_bitv (Bitvector.rotate_right bv1 bv2)
     | _ -> eval_error (`Unsupported_operator (`Binop op, Ty_bitv 0))
 
   let[@inline] relop op bv1 bv2 =

--- a/src/smtml/feature.ml
+++ b/src/smtml/feature.ml
@@ -31,6 +31,8 @@ let of_unop (unop : Ty.Unop.t) : Feature_map.feat =
   | Regexp_plus -> Regexp_plus
   | Regexp_opt -> Regexp_opt
   | Regexp_comp -> Regexp_comp
+  | Rotl _ -> Rotl
+  | Rotr _ -> Rotr
 
 let of_binop (binop : Ty.Binop.t) : Feature_map.feat =
   match binop with
@@ -52,8 +54,8 @@ let of_binop (binop : Ty.Binop.t) : Feature_map.feat =
   | Min -> Min
   | Max -> Max
   | Copysign -> Copysign
-  | Rotl -> Rotl
-  | Rotr -> Rotr
+  | Ext_rotl -> Ext_rotl
+  | Ext_rotr -> Ext_rotr
   | At -> At
   | List_cons -> List_cons
   | List_append -> List_append

--- a/src/smtml/feature.ml
+++ b/src/smtml/feature.ml
@@ -31,6 +31,8 @@ let of_unop (unop : Ty.Unop.t) : string =
   | Regexp_plus -> "Regexp_plus"
   | Regexp_opt -> "Regexp_opt"
   | Regexp_comp -> "Regexp_comp"
+  | Rotl _ -> "Rotl"
+  | Rotr _ -> "Rotr"
 
 let of_binop (binop : Ty.Binop.t) : string =
   match binop with
@@ -52,8 +54,8 @@ let of_binop (binop : Ty.Binop.t) : string =
   | Min -> "Min"
   | Max -> "Max"
   | Copysign -> "Copysign"
-  | Rotl -> "Rotl"
-  | Rotr -> "Rotr"
+  | Ext_rotl -> "Ext_rotl"
+  | Ext_rotr -> "Ext_rotr"
   | At -> "At"
   | List_cons -> "List_cons"
   | List_append -> "List_append"
@@ -211,6 +213,8 @@ let ctor_names =
       ; Regexp_plus
       ; Regexp_opt
       ; Regexp_comp
+      ; Rotl 0
+      ; Rotr 0
       ]
   in
   let binops =
@@ -233,8 +237,8 @@ let ctor_names =
       ; Min
       ; Max
       ; Copysign
-      ; Rotl
-      ; Rotr
+      ; Ext_rotl
+      ; Ext_rotr
       ; At
       ; List_cons
       ; List_append (* String *)

--- a/src/smtml/mappings.ml
+++ b/src/smtml/mappings.ml
@@ -372,6 +372,8 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
           | Popcnt -> popcnt bitwidth t
           | Neg -> Bitv.neg t
           | Not -> Bitv.lognot t
+          | Rotl n -> Bitv.rotate_left n t
+          | Rotr n -> Bitv.rotate_right n t
           | op ->
             Fmt.failwith {|%s: Unsupported %s operator "%a"|} __MODULE__
               __FUNCTION__ Unop.pp op
@@ -391,8 +393,8 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
           | ShrL -> Bitv.lshr t1 t2
           | Rem -> Bitv.rem t1 t2
           | RemU -> Bitv.rem_u t1 t2
-          | Rotl -> Bitv.rotate_left t1 t2
-          | Rotr -> Bitv.rotate_right t1 t2
+          | Ext_rotl -> Bitv.ext_rotate_left t1 t2
+          | Ext_rotr -> Bitv.ext_rotate_right t1 t2
           | op ->
             Fmt.failwith {|%s: Unsupported %s operator "%a"|} __MODULE__
               __FUNCTION__ Binop.pp op

--- a/src/smtml/mappings.nop.ml
+++ b/src/smtml/mappings.nop.ml
@@ -271,6 +271,10 @@ module M = struct
 
       let rotate_right _ = assert false
 
+      let ext_rotate_left _ = assert false
+
+      let ext_rotate_right _ = assert false
+
       let nego _ = assert false
 
       let addo ~signed:_ = assert false

--- a/src/smtml/mappings_intf.ml
+++ b/src/smtml/mappings_intf.ml
@@ -471,11 +471,18 @@ module type M = sig
         [t1] and [t2]. *)
     val rem_u : term -> term -> term
 
-    (** [rotate_left t1 t2] constructs the left rotation of [t1] by [t2]. *)
-    val rotate_left : term -> term -> term
+    (** [rotate_left n t] constructs the left rotation of [t] by [n]. *)
+    val rotate_left : int -> term -> term
 
-    (** [rotate_right t1 t2] constructs the right rotation of [t1] by [t2]. *)
-    val rotate_right : term -> term -> term
+    (** [rotate_right n t] constructs the right rotation of [t] by [n]. *)
+    val rotate_right : int -> term -> term
+
+    (** [ext_rotate_left t1 t2] constructs the left rotation of [t1] by [t2]. *)
+    val ext_rotate_left : term -> term -> term
+
+    (** [ext_rotate_right t1 t2] constructs the right rotation of [t1] by [t2].
+    *)
+    val ext_rotate_right : term -> term -> term
 
     (** [nego t] constructs a predicate that checks that whether the bit-wise
         negation of [t] does not overflow. *)

--- a/src/smtml/ty.ml
+++ b/src/smtml/ty.ml
@@ -151,6 +151,8 @@ module Unop = struct
     | Regexp_plus
     | Regexp_opt
     | Regexp_comp
+    | Rotl of int
+    | Rotr of int
   [@@deriving ord]
 
   let hash = function
@@ -188,6 +190,8 @@ module Unop = struct
     | Regexp_plus -> 25
     | Regexp_opt -> 26
     | Regexp_comp -> 27
+    | Rotl n -> combine 28 n
+    | Rotr n -> combine 29 n
 
   let equal o1 o2 =
     match (o1, o2) with
@@ -220,11 +224,12 @@ module Unop = struct
     | Regexp_opt, Regexp_opt
     | Regexp_comp, Regexp_comp ->
       true
+    | Rotl a, Rotl b | Rotr a, Rotr b -> a = b
     | ( ( Neg | Not | Clz | Popcnt | Ctz | Abs | Sqrt | Is_normal | Is_subnormal
         | Is_negative | Is_positive | Is_infinite | Is_nan | Is_zero | Ceil
         | Floor | Trunc | Nearest | Head | Tail | Reverse | Length | Trim
         | Regexp_star | Regexp_loop _ | Regexp_plus | Regexp_opt | Regexp_comp
-          )
+        | Rotl _ | Rotr _ )
       , _ ) ->
       false
 
@@ -257,6 +262,8 @@ module Unop = struct
     | Regexp_plus -> Fmt.string fmt "+"
     | Regexp_opt -> Fmt.string fmt "opt"
     | Regexp_comp -> Fmt.string fmt "comp"
+    | Rotl n -> Fmt.pf fmt "(rotl %d)" n
+    | Rotr n -> Fmt.pf fmt "(rotr %d)" n
 end
 
 module Binop = struct
@@ -279,8 +286,8 @@ module Binop = struct
     | Min
     | Max
     | Copysign
-    | Rotl
-    | Rotr
+    | Ext_rotl
+    | Ext_rotr
     | At
     | List_cons
     | List_append
@@ -315,8 +322,8 @@ module Binop = struct
     | Min -> 15
     | Max -> 16
     | Copysign -> 17
-    | Rotl -> 18
-    | Rotr -> 19
+    | Ext_rotl -> 18
+    | Ext_rotr -> 19
     | At -> 20
     | List_cons -> 21
     | List_append -> 22
@@ -351,8 +358,8 @@ module Binop = struct
     | Min, Min
     | Max, Max
     | Copysign, Copysign
-    | Rotl, Rotl
-    | Rotr, Rotr
+    | Ext_rotl, Ext_rotl
+    | Ext_rotr, Ext_rotr
     | At, At
     | List_cons, List_cons
     | List_append, List_append
@@ -366,8 +373,8 @@ module Binop = struct
     | Regexp_diff, Regexp_diff ->
       true
     | ( ( Add | Sub | Mul | Div | DivU | Rem | RemU | Shl | ShrA | ShrL | And
-        | Or | Xor | Implies | Pow | Min | Max | Copysign | Rotl | Rotr | At
-        | List_cons | List_append | String_prefix | String_suffix
+        | Or | Xor | Implies | Pow | Min | Max | Copysign | Ext_rotr | Ext_rotl
+        | At | List_cons | List_append | String_prefix | String_suffix
         | String_contains | String_last_index | String_in_re | Regexp_range
         | Regexp_inter | Regexp_diff )
       , _ ) ->
@@ -392,8 +399,8 @@ module Binop = struct
     | Min -> Fmt.string fmt "min"
     | Max -> Fmt.string fmt "max"
     | Copysign -> Fmt.string fmt "copysign"
-    | Rotl -> Fmt.string fmt "rotl"
-    | Rotr -> Fmt.string fmt "rotr"
+    | Ext_rotl -> Fmt.string fmt "ext_rotl"
+    | Ext_rotr -> Fmt.string fmt "ext_rotr"
     | At -> Fmt.string fmt "at"
     | List_cons -> Fmt.string fmt "cons"
     | List_append -> Fmt.string fmt "append"

--- a/src/smtml/ty.mli
+++ b/src/smtml/ty.mli
@@ -108,6 +108,8 @@ module Unop : sig
     | Regexp_plus  (** Kleene plus. *)
     | Regexp_opt  (** Optional. *)
     | Regexp_comp  (** Complement. *)
+    | Rotl of int  (** Rotate left. *)
+    | Rotr of int  (** Rotate right. *)
   [@@deriving ord]
 
   val hash : t -> int
@@ -143,8 +145,8 @@ module Binop : sig
     | Min  (** Minimum. *)
     | Max  (** Maximum. *)
     | Copysign  (** Copy sign. *)
-    | Rotl  (** Rotate left. *)
-    | Rotr  (** Rotate right. *)
+    | Ext_rotl  (** Extended Rotate left. *)
+    | Ext_rotr  (** Extended Rotate right. *)
     | At  (** List indexing. *)
     | List_cons  (** List construction. *)
     | List_append  (** List concatenation. *)

--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -100,9 +100,13 @@ module Bitv = struct
 
     val unsigned_rem : t -> t -> t
 
-    val rotate_left : t -> t -> t
+    val rotate_left : int -> t -> t
 
-    val rotate_right : t -> t -> t
+    val rotate_right : int -> t -> t
+
+    val ext_rotate_left : t -> t -> t
+
+    val ext_rotate_right : t -> t -> t
 
     val eq : t -> t -> bool expr
 
@@ -204,9 +208,13 @@ module Bitv = struct
 
     let[@inline] unsigned_rem x y = Expr.binop ty RemU x y
 
-    let[@inline] rotate_left x y = Expr.binop ty Rotl x y
+    let[@inline] rotate_left n x = Expr.unop ty (Rotl n) x
 
-    let[@inline] rotate_right x y = Expr.binop ty Rotr x y
+    let[@inline] rotate_right n x = Expr.unop ty (Rotr n) x
+
+    let[@inline] ext_rotate_left x y = Expr.binop ty Ext_rotl x y
+
+    let[@inline] ext_rotate_right x y = Expr.binop ty Ext_rotr x y
 
     let[@inline] eq a b = Expr.relop Ty_bool Eq a b
 

--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -100,9 +100,13 @@ module Bitv = struct
 
     val unsigned_rem : t -> t -> t
 
-    val rotate_left : t -> t -> t
+    val rotate_left : int -> t -> t
 
-    val rotate_right : t -> t -> t
+    val rotate_right : int -> t -> t
+
+    val ext_rotate_left : t -> t -> t
+
+    val ext_rotate_right : t -> t -> t
 
     val eq : t -> t -> bool expr
 
@@ -204,9 +208,25 @@ module Bitv = struct
 
     let[@inline] unsigned_rem x y = Expr.binop ty RemU x y
 
-    let[@inline] rotate_left x y = Expr.binop ty Rotl x y
+    let[@inline] rotate_left n x = Expr.unop ty (Rotl n) x
 
-    let[@inline] rotate_right x y = Expr.binop ty Rotr x y
+    let[@inline] rotate_right n x = Expr.unop ty (Rotr n) x
+
+    let[@inline] ext_rotate_left x y =
+      match Expr.view y with
+      | Val (Bitv bv) ->
+        let n = Bitvector.to_signed bv |> Z.to_int in
+        Expr.unop ty (Rotl n) x
+      | Val (Int n) -> Expr.unop ty (Rotl n) x
+      | _ -> Expr.binop ty Ext_rotl x y
+
+    let[@inline] ext_rotate_right x y =
+      match Expr.view y with
+      | Val (Bitv bv) ->
+        let n = Bitvector.to_signed bv |> Z.to_int in
+        Expr.unop ty (Rotr n) x
+      | Val (Int n) -> Expr.unop ty (Rotr n) x
+      | _ -> Expr.binop ty Ext_rotr x y
 
     let[@inline] eq a b = Expr.relop Ty_bool Eq a b
 

--- a/src/smtml/typed.mli
+++ b/src/smtml/typed.mli
@@ -466,13 +466,19 @@ module Bitv : sig
     (** [unsigned_rem t1 t2] computes the unsigned remainder of [t1 / t2]. *)
     val unsigned_rem : t -> t -> t
 
-    (** [rotate_left t amount] rotates the bits of [t] to the left by [amount].
-    *)
-    val rotate_left : t -> t -> t
+    (** [rotate_left n t] rotates the bits of [t] to the left by [n]. *)
+    val rotate_left : int -> t -> t
 
-    (** [rotate_right t amount] rotates the bits of [t] to the right by
+    (** [rotate_right n t] rotates the bits of [t] to the right by [n]. *)
+    val rotate_right : int -> t -> t
+
+    (** [ext_rotate_left t amount] rotates the bits of [t] to the left by
         [amount]. *)
-    val rotate_right : t -> t -> t
+    val ext_rotate_left : t -> t -> t
+
+    (** [ext_rotate_right t amount] rotates the bits of [t] to the right by
+        [amount]. *)
+    val ext_rotate_right : t -> t -> t
 
     (** Alias for {!Bool.eq}. *)
     val eq : t -> t -> bool expr

--- a/src/smtml/z3_mappings.default.ml
+++ b/src/smtml/z3_mappings.default.ml
@@ -351,9 +351,13 @@ module M = struct
 
       let rem_u e1 e2 = Z3.BitVector.mk_urem ctx e1 e2
 
-      let rotate_left e1 e2 = Z3.BitVector.mk_ext_rotate_left ctx e1 e2
+      let rotate_left n e = Z3.BitVector.mk_rotate_left ctx n e
 
-      let rotate_right e1 e2 = Z3.BitVector.mk_ext_rotate_right ctx e1 e2
+      let rotate_right n e = Z3.BitVector.mk_rotate_right ctx n e
+
+      let ext_rotate_left e1 e2 = Z3.BitVector.mk_ext_rotate_left ctx e1 e2
+
+      let ext_rotate_right e1 e2 = Z3.BitVector.mk_ext_rotate_right ctx e1 e2
 
       let nego e = Z3.BitVector.mk_neg_no_overflow ctx e
 

--- a/src/smtzilla_utils/feature_map.ml
+++ b/src/smtzilla_utils/feature_map.ml
@@ -68,6 +68,8 @@ type feat =
   | Copysign
   | Rotl
   | Rotr
+  | Ext_rotl
+  | Ext_rotr
   | At
   | List_cons
   | List_append
@@ -253,6 +255,8 @@ let feat_to_string = function
   | Copysign -> "Copysign"
   | Rotl -> "Rotl"
   | Rotr -> "Rotr"
+  | Ext_rotl -> "Ext_rotl"
+  | Ext_rotr -> "Ext_rotr"
   | At -> "At"
   | List_cons -> "List_cons"
   | List_append -> "List_append"
@@ -392,6 +396,8 @@ let feat_of_string = function
   | "Copysign" -> Copysign
   | "Rotl" -> Rotl
   | "Rotr" -> Rotr
+  | "Ext_rotl" -> Ext_rotl
+  | "Ext_rotr" -> Ext_rotr
   | "At" -> At
   | "List_cons" -> List_cons
   | "List_append" -> List_append

--- a/src/smtzilla_utils/feature_map.mli
+++ b/src/smtzilla_utils/feature_map.mli
@@ -68,6 +68,8 @@ type feat =
   | Copysign
   | Rotl
   | Rotr
+  | Ext_rotl
+  | Ext_rotr
   | At
   | List_cons
   | List_append

--- a/test/integration/test_solver.ml
+++ b/test/integration/test_solver.ml
@@ -203,11 +203,47 @@ module Make (M : Mappings_intf.S_with_fresh) = struct
     done;
     assert_sat ~f:"test_arbitrary_bv" (Solver.check solver [])
 
+  let test_bv_rotate solver_module =
+    let open Typed in
+    let module Solver = (val solver_module : Solver_intf.S) in
+    let solver = Solver.create ~params:(Params.default ()) ~logic:QF_BVFP () in
+    let x = symbol Types.bitv8 "rotate_x" in
+    let input = Bitv8.of_int 0x36 in
+    let rotated_left = Bitv8.rotate_left 3 x in
+    let rotated_right = Bitv8.rotate_right 3 x in
+    Solver.add solver
+      [ (Bool.eq x input :> Expr.t)
+      ; (Bool.eq rotated_left (Bitv8.of_int 0xB1) :> Expr.t)
+      ; (Bool.eq rotated_right (Bitv8.of_int 0xC6) :> Expr.t)
+      ];
+    assert_sat ~f:"test_bv_rotate" (Solver.check solver []);
+    Solver.add solver [ (Bool.eq rotated_left (Bitv8.of_int 0xB0) :> Expr.t) ];
+    assert_unsat ~f:"test_bv_rotate_inconsistent" (Solver.check solver [])
+
+  let test_bv_ext_rotate solver_module =
+    let open Typed in
+    let module Solver = (val solver_module : Solver_intf.S) in
+    let solver = Solver.create ~params:(Params.default ()) ~logic:QF_BVFP () in
+    let x = symbol Types.bitv8 "ext_rotate_x" in
+    let shift = symbol Types.bitv8 "ext_rotate_shift" in
+    let rotated_left = Bitv8.ext_rotate_left x shift in
+    let rotated_right = Bitv8.ext_rotate_right x shift in
+    Solver.add solver
+      [ (Bool.eq x (Bitv8.of_int 0x36) :> Expr.t)
+      ; (Bool.eq shift (Bitv8.of_int 3) :> Expr.t)
+      ; (Bool.eq rotated_left (Bitv8.of_int 0xB1) :> Expr.t)
+      ; (Bool.eq rotated_right (Bitv8.of_int 0xC6) :> Expr.t)
+      ];
+    assert_sat ~f:"test_bv_ext_rotate" (Solver.check solver []);
+    Solver.add solver [ (Bool.eq rotated_right (Bitv8.of_int 0xC7) :> Expr.t) ];
+    assert_unsat ~f:"test_bv_ext_rotate_inconsistent" (Solver.check solver [])
+
   let test_bv =
     "test_bv"
     >::: [ "test_bv_8" >:: with_solver test_bv_8
          ; "test_bv_32" >:: with_solver test_bv_32
          ; "test_arbitrary_bv" >:: with_solver test_arbitrary_bv
+         ; "test_bv_rotate" >:: with_solver test_bv_rotate
          ]
 
   let test_fp_get_value32 solver_module =

--- a/test/integration/test_solver_bitwuzla.ml
+++ b/test/integration/test_solver_bitwuzla.ml
@@ -11,6 +11,8 @@ let test_suite =
   >::: [ is_available
        ; Bitwuzla.test_params
        ; Bitwuzla.test_bv
+       ; "test_bv_ext_rotate"
+         >:: Bitwuzla.with_solver Bitwuzla.test_bv_ext_rotate
        ; Bitwuzla.test_fp
        ; Bitwuzla.test_extract
        ; Bitwuzla.test_typed_api_consistency

--- a/test/integration/test_solver_z3.ml
+++ b/test/integration/test_solver_z3.ml
@@ -17,6 +17,7 @@ let test_suite =
        ; Z3_solv.test_lia
        ; Z3_solv.test_lra
        ; Z3_solv.test_bv
+       ; "test_bv_ext_rotate" >:: Z3_solv.with_solver Z3_solv.test_bv_ext_rotate
        ; Z3_solv.test_fp
        ; Z3_solv.test_regexp
        ; Z3_solv.test_uninterpreted

--- a/test/unit/test_eval.ml
+++ b/test/unit/test_eval.ml
@@ -799,11 +799,32 @@ module F64Cvtop_test = struct
     ]
 end
 
+module Bitv_test = struct
+  let ty = Ty.Ty_bitv 8
+
+  let unop =
+    [ ( "test_rotate_left" >:: fun _ ->
+        assert_equal (int8 0xB1) (Eval.unop ty (Rotl 3) (int8 0x36)) )
+    ; ( "test_rotate_right" >:: fun _ ->
+        assert_equal (int8 0xC6) (Eval.unop ty (Rotr 3) (int8 0x36)) )
+    ]
+
+  let binop =
+    [ ( "test_ext_rotate_left" >:: fun _ ->
+        assert_equal (int8 0xB1) (Eval.binop ty Ext_rotl (int8 0x36) (int8 3))
+      )
+    ; ( "test_ext_rotate_right" >:: fun _ ->
+        assert_equal (int8 0xC6) (Eval.binop ty Ext_rotr (int8 0x36) (int8 3))
+      )
+    ]
+end
+
 let test_unop =
   [ "Int_test.unop" >::: Int_test.unop
   ; "Real_test.unop" >::: Real_test.unop
   ; "Bool_test.unop" >::: Bool_test.unop
   ; "Str_test.unop" >::: Str_test.unop
+  ; "Bitv_test.unop" >::: Bitv_test.unop
   ; "F32_test.unop" >::: F32_test.unop
   ; "F64_test.unop" >::: F64_test.unop
   ]
@@ -813,6 +834,7 @@ let test_binop =
   ; "Real_test.binop" >::: Real_test.binop
   ; "Bool_test.binop" >::: Bool_test.binop
   ; "Str_test.binop" >::: Str_test.binop
+  ; "Bitv_test.binop" >::: Bitv_test.binop
   ; "F32_test.binop" >::: F32_test.binop
   ; "F64_test.binop" >::: F64_test.binop
   ]

--- a/test/unit/test_eval.ml
+++ b/test/unit/test_eval.ml
@@ -795,11 +795,32 @@ module F64Cvtop_test = struct
     ]
 end
 
+module Bitv_test = struct
+  let ty = Ty.Ty_bitv 8
+
+  let unop =
+    [ ( "test_rotate_left" >:: fun _ ->
+        assert_equal (int8 0xB1) (Eval.unop ty (Rotl 3) (int8 0x36)) )
+    ; ( "test_rotate_right" >:: fun _ ->
+        assert_equal (int8 0xC6) (Eval.unop ty (Rotr 3) (int8 0x36)) )
+    ]
+
+  let binop =
+    [ ( "test_ext_rotate_left" >:: fun _ ->
+        assert_equal (int8 0xB1) (Eval.binop ty Ext_rotl (int8 0x36) (int8 3))
+      )
+    ; ( "test_ext_rotate_right" >:: fun _ ->
+        assert_equal (int8 0xC6) (Eval.binop ty Ext_rotr (int8 0x36) (int8 3))
+      )
+    ]
+end
+
 let test_unop =
   [ "Int_test.unop" >::: Int_test.unop
   ; "Real_test.unop" >::: Real_test.unop
   ; "Bool_test.unop" >::: Bool_test.unop
   ; "Str_test.unop" >::: Str_test.unop
+  ; "Bitv_test.unop" >::: Bitv_test.unop
   ; "F32_test.unop" >::: F32_test.unop
   ; "F64_test.unop" >::: F64_test.unop
   ]
@@ -809,6 +830,7 @@ let test_binop =
   ; "Real_test.binop" >::: Real_test.binop
   ; "Bool_test.binop" >::: Bool_test.binop
   ; "Str_test.binop" >::: Str_test.binop
+  ; "Bitv_test.binop" >::: Bitv_test.binop
   ; "F32_test.binop" >::: F32_test.binop
   ; "F64_test.binop" >::: F64_test.binop
   ]

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -188,10 +188,10 @@ let test_binop_i32 _ =
   check (Expr.binop (Ty_bitv 32) Shl (int32 1l) (int32 2l)) (int32 4l);
   check (Expr.binop (Ty_bitv 32) ShrA (int32 4l) (int32 2l)) (int32 1l);
   check
-    (Expr.binop (Ty_bitv 32) Rotl (int32 Int32.min_int) (int32 2l))
+    (Expr.binop (Ty_bitv 32) Ext_rotl (int32 Int32.min_int) (int32 2l))
     (int32 2l);
   check
-    Expr.(binop (Ty_bitv 32) Rotr (int32 2l) (int32 2l))
+    Expr.(binop (Ty_bitv 32) Ext_rotr (int32 2l) (int32 2l))
     (int32 Int32.min_int)
 
 let test_binop_i64 _ =
@@ -207,10 +207,10 @@ let test_binop_i64 _ =
   check (Expr.binop (Ty_bitv 64) Shl (int64 1L) (int64 2L)) (int64 4L);
   check (Expr.binop (Ty_bitv 64) ShrA (int64 4L) (int64 2L)) (int64 1L);
   check
-    (Expr.binop (Ty_bitv 64) Rotl (int64 Int64.min_int) (int64 2L))
+    (Expr.binop (Ty_bitv 64) Ext_rotl (int64 Int64.min_int) (int64 2L))
     (int64 2L);
   check
-    (Expr.binop (Ty_bitv 64) Rotr (int64 2L) (int64 2L))
+    (Expr.binop (Ty_bitv 64) Ext_rotr (int64 2L) (int64 2L))
     (int64 Int64.min_int)
 
 let test_binop_f32 _ =


### PR DESCRIPTION
This is needed because some solvers may follow the SMT-LIB standard strictly and only implement the rotate operators using indicies.

Closes #625
Closes #627

BREAKING: This change intentionally breaks the `rotate_{left,right}` operators to take an integer as the first argument. This is to force users to make a decision on whether to continue using the previous behavior with `ext_rotate_{left,right}` or start using the new API.