### PR TITLE
fix: ty.ml discr collision, LeU SMT-LIB pp, to_int64 error msg, test …

### DIFF
--- a/src/smtml/bitvector.ml
+++ b/src/smtml/bitvector.ml
@@ -57,7 +57,7 @@ let to_int32 v =
 let to_int64 v =
   if numbits v <= 64 then Z.to_int64 (to_signed v)
   else
-    Fmt.failwith "call to Smtml.Bitvector.to_int32 on a bitvector of size %d"
+    Fmt.failwith "call to Smtml.Bitvector.to_int64 on a bitvector of size %d"
       v.width
 
 (** Bitvector pretty printer. By default it prints signed bitvectors. *)

--- a/src/smtml/ty.ml
+++ b/src/smtml/ty.ml
@@ -32,8 +32,8 @@ let discr = function
   | Ty_unit -> 7
   | Ty_regexp -> 8
   | Ty_roundingMode -> 9
-  | Ty_bitv n -> 10 + n
-  | Ty_fp n -> 11 + n
+  | Ty_bitv n -> 10 + (2 * n)
+  | Ty_fp n -> 11 + (2 * n)
 
 (* Optimized mixer (DJB2 variant). Inlines to simple arithmetic. *)
 let[@inline] combine h v = (h * 33) + v
@@ -718,5 +718,5 @@ module Smtlib = struct
     | Ty_bitv _, Le -> Fmt.string fmt "bvsle"
     | _, Le -> Fmt.string fmt "<="
     | Ty_bitv _, LeU -> Fmt.string fmt "bvule"
-    | _, LeU -> Fmt.string fmt ">="
+    | _, LeU -> Fmt.string fmt "<="
 end

--- a/test/unit/test_bitvector.ml
+++ b/test/unit/test_bitvector.ml
@@ -239,10 +239,6 @@ let test_to_int32 _ =
   let expected = -1853712862l in
   assert_equal expected actual
 
-let test_to_int64 _ =
-  (* TODO *)
-  ()
-
 let test_suite =
   "Bitvector"
   >::: [ "test_make" >:: test_make
@@ -271,7 +267,6 @@ let test_suite =
        ; "test_extract" >::: test_extract
        ; "test_concat" >::: test_concat
        ; "test_to_int32" >:: test_to_int32
-       ; "test_to_int64" >:: test_to_int64
        ]
 
 let () = run_test_tt_main test_suite

--- a/test/unit/test_eval.ml
+++ b/test/unit/test_eval.ml
@@ -131,10 +131,10 @@ module Int_test = struct
       assert_bool "2 <= 3" (Eval.relop Ty_int Le (int 3) (int 3))
     in
     let test_gt _ =
-      assert_bool "4 > 4" (Eval.relop Ty_int Lt (int 3) (int 4))
+      assert_bool "3 < 4" (Eval.relop Ty_int Lt (int 3) (int 4))
     in
     let test_ge _ =
-      assert_bool "4 >= 4" (Eval.relop Ty_int Le (int 4) (int 4))
+      assert_bool "4 <= 4" (Eval.relop Ty_int Le (int 4) (int 4))
     in
 
     [ "test_lt" >:: test_lt


### PR DESCRIPTION
…cleanups

- ty.ml: make Ty_bitv and Ty_fp discr non-overlapping (10+2n vs 11+2n)
- ty.ml: fix LeU catch-all SMT-LIB printer from ">=" to "<="
- bitvector.ml: fix to_int64 error message (said to_int32)
- test_bitvector.ml: remove empty test_to_int64 TODO stub
- test_eval.ml: fix test_gt/test_ge assertion messages