### PR TITLE
start to add various submodules for Bv128

### DIFF
--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -551,6 +551,8 @@ module Bitv128 = struct
       of_i8x16 w1 w2 w3 w4 w5 w6 w7 w8 w9 w10 w11 w12 w13 w14 w15 w16
 
     let eq u v = map2 Bitv8.eq u v
+
+    let splat v = of_i8x16 v v v v v v v v v v v v v v v v
   end
 
   module I16x8 = struct
@@ -580,6 +582,8 @@ module Bitv128 = struct
       of_i16x8 w1 w2 w3 w4 w5 w6 w7 w8
 
     let eq u v = map2 Bitv16.eq u v
+
+    let splat v = of_i16x8 v v v v v v v v
   end
 
   module I32x4 = struct
@@ -601,6 +605,8 @@ module Bitv128 = struct
       of_i32x4 w1 w2 w3 w4
 
     let eq u v = map2 Bitv32.eq u v
+
+    let splat v = of_i32x4 v v v v
   end
 
   module I64x2 = struct
@@ -618,6 +624,8 @@ module Bitv128 = struct
       of_i64x2 w1 w2
 
     let eq u v = map2 Bitv64.eq u v
+
+    let splat v = of_i64x2 v v
   end
 end
 

--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -553,6 +553,9 @@ module Bitv128 = struct
     let eq u v = map2 Bitv8.eq u v
 
     let splat v = of_i8x16 v v v v v v v v v v v v v v v v
+
+    let add x y = map2 Bitv8.add x y
+    let sub x y = map2 Bitv8.sub x y
   end
 
   module I16x8 = struct
@@ -584,6 +587,9 @@ module Bitv128 = struct
     let eq u v = map2 Bitv16.eq u v
 
     let splat v = of_i16x8 v v v v v v v v
+
+    let add x y = map2 Bitv16.add x y
+    let sub x y = map2 Bitv16.sub x y
   end
 
   module I32x4 = struct
@@ -607,6 +613,9 @@ module Bitv128 = struct
     let eq u v = map2 Bitv32.eq u v
 
     let splat v = of_i32x4 v v v v
+
+    let add x y = map2 Bitv32.add x y
+    let sub x y = map2 Bitv32.sub x y
   end
 
   module I64x2 = struct
@@ -626,6 +635,8 @@ module Bitv128 = struct
     let eq u v = map2 Bitv64.eq u v
 
     let splat v = of_i64x2 v v
+    let add x y = map2 Bitv64.add x y
+    let sub x y = map2 Bitv64.sub x y
   end
 end
 

--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -38,7 +38,6 @@ let[@inline] get_symbols (x : 'a expr list) : Symbol.t list = Expr.get_symbols x
 let[@inline] ptr (base : int32) (offset : bitv32 expr) : bitv32 expr =
   Expr.ptr base offset
 
-
 let ty_bool : bool ty = Ty_bool
 
 module Bool = struct
@@ -593,11 +592,16 @@ module Bitv128 = struct
       let w16 = f u16 v16 in
       of_i8x16 w1 w2 w3 w4 w5 w6 w7 w8 w9 w10 w11 w12 w13 w14 w15 w16
 
-    let eq u v = map2 Bitv8.eq u v
+    let eq u v =
+      map2
+        (fun x y ->
+          Bool.ite (Bitv8.eq x y) (Bitv8.of_int 0xFF) (Bitv8.of_int 0x00) )
+        u v
 
     let splat v = of_i8x16 v v v v v v v v v v v v v v v v
 
     let add x y = map2 Bitv8.add x y
+
     let sub x y = map2 Bitv8.sub x y
   end
 
@@ -627,11 +631,16 @@ module Bitv128 = struct
       let w8 = f u8 v8 in
       of_i16x8 w1 w2 w3 w4 w5 w6 w7 w8
 
-    let eq u v = map2 Bitv16.eq u v
+    let eq u v =
+      map2
+        (fun x y ->
+          Bool.ite (Bitv16.eq x y) (Bitv16.of_int 0xFFFF) (Bitv16.of_int 0x0000) )
+        u v
 
     let splat v = of_i16x8 v v v v v v v v
 
     let add x y = map2 Bitv16.add x y
+
     let sub x y = map2 Bitv16.sub x y
   end
 
@@ -653,11 +662,16 @@ module Bitv128 = struct
       let w4 = f u4 v4 in
       of_i32x4 w1 w2 w3 w4
 
-    let eq u v = map2 Bitv32.eq u v
+    let eq u v =
+      map2
+        (fun x y ->
+          Bool.ite (Bitv32.eq x y) (Bitv32.of_int 0xFFFF) (Bitv32.of_int 0x0000) )
+        u v
 
     let splat v = of_i32x4 v v v v
 
     let add x y = map2 Bitv32.add x y
+
     let sub x y = map2 Bitv32.sub x y
   end
 
@@ -675,10 +689,18 @@ module Bitv128 = struct
       let w2 = f u2 v2 in
       of_i64x2 w1 w2
 
-    let eq u v = map2 Bitv64.eq u v
+    let eq u v =
+      map2
+        (fun x y ->
+          Bool.ite (Bitv64.eq x y)
+            (Bitv64.of_int64 0xFFFFFFFFL)
+            (Bitv64.of_int64 0x00000000L) )
+        u v
 
     let splat v = of_i64x2 v v
+
     let add x y = map2 Bitv64.add x y
+
     let sub x y = map2 Bitv64.sub x y
   end
 

--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -38,6 +38,49 @@ let[@inline] get_symbols (x : 'a expr list) : Symbol.t list = Expr.get_symbols x
 let[@inline] ptr (base : int32) (offset : bitv32 expr) : bitv32 expr =
   Expr.ptr base offset
 
+
+let ty_bool : bool ty = Ty_bool
+
+module Bool = struct
+  type t = bool expr
+
+  let true_ = Expr.value True
+
+  let false_ = Expr.value False
+
+  let of_bool x = if x then true_ else false_
+
+  let[@inline] symbol x = Expr.symbol x
+
+  let[@inline] pp fmt x = Expr.pp fmt x
+
+  let[@inline] not e = Expr.Bool.not e
+
+  let[@inline] and_ a b = Expr.Bool.and_ a b
+
+  let[@inline] or_ a b = Expr.Bool.or_ a b
+
+  let[@inline] logand es = Expr.naryop ty_bool Logand es
+
+  let[@inline] logor es = Expr.naryop ty_bool Logor es
+
+  let[@inline] xor a b = Expr.binop ty_bool Xor a b
+
+  let[@inline] implies a b = Expr.Bool.implies a b
+
+  let[@inline] eq (a : 'a expr) (b : 'a expr) = Expr.relop ty_bool Eq a b
+
+  let[@inline] distinct (es : 'a expr list) =
+    (* Typically this encodes a symbolic constraint: (distinct x y z), so no
+       need to waste time trying to simplify. Just use `raw_naryop`. *)
+    Expr.raw_naryop ty_bool Distinct es
+
+  let[@inline] ite c (r1 : 'a expr) (r2 : 'a expr) : 'a expr =
+    Expr.triop ty_bool Ite c r1 r2
+
+  let[@inline] split_conjunctions x = Expr.split_conjunctions x
+end
+
 module Bitv = struct
   module type Width = sig
     type w
@@ -638,6 +681,8 @@ module Bitv128 = struct
     let add x y = map2 Bitv64.add x y
     let sub x y = map2 Bitv64.sub x y
   end
+
+  let any_true v = Bool.not (eq v zero)
 end
 
 module Types = struct
@@ -647,7 +692,7 @@ module Types = struct
 
   let regexp : regexp ty = Ty_regexp
 
-  let bool : bool ty = Ty_bool
+  let bool : bool ty = ty_bool
 
   let string : string ty = Ty_str
 
@@ -668,46 +713,6 @@ module Types = struct
   let pp fmt ty = Ty.pp fmt ty
 
   let[@inline] to_ty (ty : 'a ty) : Ty.t = ty
-end
-
-module Bool = struct
-  type t = bool expr
-
-  let true_ = Expr.value True
-
-  let false_ = Expr.value False
-
-  let of_bool x = if x then true_ else false_
-
-  let[@inline] symbol x = Expr.symbol x
-
-  let[@inline] pp fmt x = Expr.pp fmt x
-
-  let[@inline] not e = Expr.Bool.not e
-
-  let[@inline] and_ a b = Expr.Bool.and_ a b
-
-  let[@inline] or_ a b = Expr.Bool.or_ a b
-
-  let[@inline] logand es = Expr.naryop Types.bool Logand es
-
-  let[@inline] logor es = Expr.naryop Types.bool Logor es
-
-  let[@inline] xor a b = Expr.binop Types.bool Xor a b
-
-  let[@inline] implies a b = Expr.Bool.implies a b
-
-  let[@inline] eq (a : 'a expr) (b : 'a expr) = Expr.relop Types.bool Eq a b
-
-  let[@inline] distinct (es : 'a expr list) =
-    (* Typically this encodes a symbolic constraint: (distinct x y z), so no
-       need to waste time trying to simplify. Just use `raw_naryop`. *)
-    Expr.raw_naryop Types.bool Distinct es
-
-  let[@inline] ite c (r1 : 'a expr) (r2 : 'a expr) : 'a expr =
-    Expr.triop Types.bool Ite c r1 r2
-
-  let[@inline] split_conjunctions x = Expr.split_conjunctions x
 end
 
 module Int = struct

--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -565,6 +565,29 @@ module Bitv128 = struct
       let v16 = f v16 in
       of_i8x16 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16
 
+    let mapi f v =
+      let v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16
+          =
+        to_i8x16 v
+      in
+      let v1 = f 0 v1 in
+      let v2 = f 1 v2 in
+      let v3 = f 2 v3 in
+      let v4 = f 3 v4 in
+      let v5 = f 4 v5 in
+      let v6 = f 5 v6 in
+      let v7 = f 6 v7 in
+      let v8 = f 7 v8 in
+      let v9 = f 8 v9 in
+      let v10 = f 9 v10 in
+      let v11 = f 10 v11 in
+      let v12 = f 11 v12 in
+      let v13 = f 12 v13 in
+      let v14 = f 13 v14 in
+      let v15 = f 14 v15 in
+      let v16 = f 15 v16 in
+      of_i8x16 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16
+
     let map2 f u v =
       let u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11, u12, u13, u14, u15, u16
           =
@@ -592,6 +615,29 @@ module Bitv128 = struct
       let w16 = f u16 v16 in
       of_i8x16 w1 w2 w3 w4 w5 w6 w7 w8 w9 w10 w11 w12 w13 w14 w15 w16
 
+    let fold_left f acc v =
+      let v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16
+          =
+        to_i8x16 v
+      in
+      let acc = f acc v1 in
+      let acc = f acc v2 in
+      let acc = f acc v3 in
+      let acc = f acc v4 in
+      let acc = f acc v5 in
+      let acc = f acc v6 in
+      let acc = f acc v7 in
+      let acc = f acc v8 in
+      let acc = f acc v9 in
+      let acc = f acc v10 in
+      let acc = f acc v11 in
+      let acc = f acc v12 in
+      let acc = f acc v13 in
+      let acc = f acc v14 in
+      let acc = f acc v15 in
+      let acc = f acc v16 in
+      acc
+
     let eq u v =
       map2
         (fun x y ->
@@ -599,6 +645,24 @@ module Bitv128 = struct
         u v
 
     let splat v = of_i8x16 v v v v v v v v v v v v v v v v
+
+    let bitmask v =
+      let _i, acc =
+        fold_left
+          (fun (i, acc) lane ->
+            let sign =
+              Bool.not
+                (Bitv8.eq (Bitv8.logand lane (Bitv8.of_int 0x80)) Bitv8.zero)
+            in
+            let bit =
+              Bool.ite sign
+                (Bitv32.shl (Bitv32.of_int 1) (Bitv32.of_int i))
+                Bitv32.zero
+            in
+            (succ i, Bitv32.logor acc bit) )
+          (0, Bitv32.zero) v
+      in
+      acc
 
     let add x y = map2 Bitv8.add x y
 
@@ -618,6 +682,18 @@ module Bitv128 = struct
       let v8 = f v8 in
       of_i16x8 v1 v2 v3 v4 v5 v6 v7 v8
 
+    let mapi f v =
+      let v1, v2, v3, v4, v5, v6, v7, v8 = to_i16x8 v in
+      let v1 = f 0 v1 in
+      let v2 = f 1 v2 in
+      let v3 = f 2 v3 in
+      let v4 = f 3 v4 in
+      let v5 = f 4 v5 in
+      let v6 = f 5 v6 in
+      let v7 = f 6 v7 in
+      let v8 = f 7 v8 in
+      of_i16x8 v1 v2 v3 v4 v5 v6 v7 v8
+
     let map2 f u v =
       let u1, u2, u3, u4, u5, u6, u7, u8 = to_i16x8 u in
       let v1, v2, v3, v4, v5, v6, v7, v8 = to_i16x8 v in
@@ -631,6 +707,18 @@ module Bitv128 = struct
       let w8 = f u8 v8 in
       of_i16x8 w1 w2 w3 w4 w5 w6 w7 w8
 
+    let fold_left f acc v =
+      let v1, v2, v3, v4, v5, v6, v7, v8 = to_i16x8 v in
+      let acc = f acc v1 in
+      let acc = f acc v2 in
+      let acc = f acc v3 in
+      let acc = f acc v4 in
+      let acc = f acc v5 in
+      let acc = f acc v6 in
+      let acc = f acc v7 in
+      let acc = f acc v8 in
+      acc
+
     let eq u v =
       map2
         (fun x y ->
@@ -638,6 +726,27 @@ module Bitv128 = struct
         u v
 
     let splat v = of_i16x8 v v v v v v v v
+
+    let bitmask v =
+      let _i, acc =
+        fold_left
+          (fun (i, acc) lane ->
+            let sign =
+              Bool.not
+                (Bitv16.eq
+                   (Bitv16.logand lane (Bitv16.of_int 0x8000))
+                   Bitv16.zero )
+            in
+            let acc =
+              Bitv32.logor acc
+                (Bool.ite sign
+                   (Bitv32.shl (Bitv32.of_int 1) (Bitv32.of_int i))
+                   Bitv32.zero )
+            in
+            (succ i, acc) )
+          (0, Bitv32.zero) v
+      in
+      acc
 
     let add x y = map2 Bitv16.add x y
 
@@ -653,6 +762,14 @@ module Bitv128 = struct
       let v4 = f v4 in
       of_i32x4 v1 v2 v3 v4
 
+    let mapi f v =
+      let v1, v2, v3, v4 = to_i32x4 v in
+      let v1 = f 0 v1 in
+      let v2 = f 1 v2 in
+      let v3 = f 2 v3 in
+      let v4 = f 3 v4 in
+      of_i32x4 v1 v2 v3 v4
+
     let map2 f u v =
       let u1, u2, u3, u4 = to_i32x4 u in
       let v1, v2, v3, v4 = to_i32x4 v in
@@ -662,6 +779,14 @@ module Bitv128 = struct
       let w4 = f u4 v4 in
       of_i32x4 w1 w2 w3 w4
 
+    let fold_left f acc v =
+      let v1, v2, v3, v4 = to_i32x4 v in
+      let acc = f acc v1 in
+      let acc = f acc v2 in
+      let acc = f acc v3 in
+      let acc = f acc v4 in
+      acc
+
     let eq u v =
       map2
         (fun x y ->
@@ -669,6 +794,21 @@ module Bitv128 = struct
         u v
 
     let splat v = of_i32x4 v v v v
+
+    let bitmask v =
+      mapi
+        (fun i lane ->
+          let sign =
+            Bool.not
+              (Bitv32.eq
+                 (Bitv32.logand lane (Bitv32.of_int32 Int32.min_int))
+                 Bitv32.zero )
+          in
+          Bool.ite sign
+            (Bitv32.shl (Bitv32.of_int 1) (Bitv32.of_int i))
+            Bitv32.zero )
+        v
+      |> fold_left Bitv32.logor Bitv32.zero
 
     let add x y = map2 Bitv32.add x y
 
@@ -682,12 +822,24 @@ module Bitv128 = struct
       let v2 = f v2 in
       of_i64x2 v1 v2
 
+    let mapi f v =
+      let v1, v2 = to_i64x2 v in
+      let v1 = f 0 v1 in
+      let v2 = f 1 v2 in
+      of_i64x2 v1 v2
+
     let map2 f u v =
       let u1, u2 = to_i64x2 u in
       let v1, v2 = to_i64x2 v in
       let w1 = f u1 v1 in
       let w2 = f u2 v2 in
       of_i64x2 w1 w2
+
+    let fold_left f acc v =
+      let v1, v2 = to_i64x2 v in
+      let acc = f acc v1 in
+      let acc = f acc v2 in
+      acc
 
     let eq u v =
       map2
@@ -698,6 +850,27 @@ module Bitv128 = struct
         u v
 
     let splat v = of_i64x2 v v
+
+    let bitmask v =
+      let _i, acc =
+        fold_left
+          (fun (i, acc) lane ->
+            let sign =
+              Bool.not
+                (Bitv64.eq
+                   (Bitv64.logand lane (Bitv64.of_int64 0x8000000000000000L))
+                   Bitv64.zero )
+            in
+            let acc =
+              Bitv32.logor acc
+                (Bool.ite sign
+                   (Bitv32.shl (Bitv32.of_int 1) (Bitv32.of_int i))
+                   Bitv32.zero )
+            in
+            (succ i, acc) )
+          (0, Bitv32.zero) v
+      in
+      acc
 
     let add x y = map2 Bitv64.add x y
 

--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -790,7 +790,9 @@ module Bitv128 = struct
     let eq u v =
       map2
         (fun x y ->
-          Bool.ite (Bitv32.eq x y) (Bitv32.of_int 0xFFFF) (Bitv32.of_int 0x0000) )
+          Bool.ite (Bitv32.eq x y)
+            (Bitv32.of_int32 0xFFFFFFFFl)
+            (Bitv32.of_int32 0x00000000l) )
         u v
 
     let splat v = of_i32x4 v v v v
@@ -845,8 +847,8 @@ module Bitv128 = struct
       map2
         (fun x y ->
           Bool.ite (Bitv64.eq x y)
-            (Bitv64.of_int64 0xFFFFFFFFL)
-            (Bitv64.of_int64 0x00000000L) )
+            (Bitv64.of_int64 0xFFFFFFFFFFFFFFFFL)
+            (Bitv64.of_int64 0x0000000000000000L) )
         u v
 
     let splat v = of_i64x2 v v

--- a/src/smtml/typed.ml
+++ b/src/smtml/typed.ml
@@ -498,6 +498,127 @@ module Bitv128 = struct
   let of_i64x2 a b = Bitv64.concat a b
 
   let to_i64x2 v = (extract v ~low:64 ~high:127, extract v ~low:0 ~high:63)
+
+  module I8x16 = struct
+    let map f v =
+      let v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16
+          =
+        to_i8x16 v
+      in
+      let v1 = f v1 in
+      let v2 = f v2 in
+      let v3 = f v3 in
+      let v4 = f v4 in
+      let v5 = f v5 in
+      let v6 = f v6 in
+      let v7 = f v7 in
+      let v8 = f v8 in
+      let v9 = f v9 in
+      let v10 = f v10 in
+      let v11 = f v11 in
+      let v12 = f v12 in
+      let v13 = f v13 in
+      let v14 = f v14 in
+      let v15 = f v15 in
+      let v16 = f v16 in
+      of_i8x16 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16
+
+    let map2 f u v =
+      let u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11, u12, u13, u14, u15, u16
+          =
+        to_i8x16 u
+      in
+      let v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16
+          =
+        to_i8x16 v
+      in
+      let w1 = f u1 v1 in
+      let w2 = f u2 v2 in
+      let w3 = f u3 v3 in
+      let w4 = f u4 v4 in
+      let w5 = f u5 v5 in
+      let w6 = f u6 v6 in
+      let w7 = f u7 v7 in
+      let w8 = f u8 v8 in
+      let w9 = f u9 v9 in
+      let w10 = f u10 v10 in
+      let w11 = f u11 v11 in
+      let w12 = f u12 v12 in
+      let w13 = f u13 v13 in
+      let w14 = f u14 v14 in
+      let w15 = f u15 v15 in
+      let w16 = f u16 v16 in
+      of_i8x16 w1 w2 w3 w4 w5 w6 w7 w8 w9 w10 w11 w12 w13 w14 w15 w16
+
+    let eq u v = map2 Bitv8.eq u v
+  end
+
+  module I16x8 = struct
+    let map f v =
+      let v1, v2, v3, v4, v5, v6, v7, v8 = to_i16x8 v in
+      let v1 = f v1 in
+      let v2 = f v2 in
+      let v3 = f v3 in
+      let v4 = f v4 in
+      let v5 = f v5 in
+      let v6 = f v6 in
+      let v7 = f v7 in
+      let v8 = f v8 in
+      of_i16x8 v1 v2 v3 v4 v5 v6 v7 v8
+
+    let map2 f u v =
+      let u1, u2, u3, u4, u5, u6, u7, u8 = to_i16x8 u in
+      let v1, v2, v3, v4, v5, v6, v7, v8 = to_i16x8 v in
+      let w1 = f u1 v1 in
+      let w2 = f u2 v2 in
+      let w3 = f u3 v3 in
+      let w4 = f u4 v4 in
+      let w5 = f u5 v5 in
+      let w6 = f u6 v6 in
+      let w7 = f u7 v7 in
+      let w8 = f u8 v8 in
+      of_i16x8 w1 w2 w3 w4 w5 w6 w7 w8
+
+    let eq u v = map2 Bitv16.eq u v
+  end
+
+  module I32x4 = struct
+    let map f v =
+      let v1, v2, v3, v4 = to_i32x4 v in
+      let v1 = f v1 in
+      let v2 = f v2 in
+      let v3 = f v3 in
+      let v4 = f v4 in
+      of_i32x4 v1 v2 v3 v4
+
+    let map2 f u v =
+      let u1, u2, u3, u4 = to_i32x4 u in
+      let v1, v2, v3, v4 = to_i32x4 v in
+      let w1 = f u1 v1 in
+      let w2 = f u2 v2 in
+      let w3 = f u3 v3 in
+      let w4 = f u4 v4 in
+      of_i32x4 w1 w2 w3 w4
+
+    let eq u v = map2 Bitv32.eq u v
+  end
+
+  module I64x2 = struct
+    let map f v =
+      let v1, v2 = to_i64x2 v in
+      let v1 = f v1 in
+      let v2 = f v2 in
+      of_i64x2 v1 v2
+
+    let map2 f u v =
+      let u1, u2 = to_i64x2 u in
+      let v1, v2 = to_i64x2 v in
+      let w1 = f u1 v1 in
+      let w2 = f u2 v2 in
+      of_i64x2 w1 w2
+
+    let eq u v = map2 Bitv64.eq u v
+  end
 end
 
 module Types = struct

--- a/src/smtml/typed.mli
+++ b/src/smtml/typed.mli
@@ -786,6 +786,8 @@ module Bitv128 : sig
   (** [to_i64x2] splits the 128-bit vector into two 64-bit terms. *)
   val to_i64x2 : t -> bitv64 expr * bitv64 expr
 
+  val any_true : t -> Bool.t
+
   module I8x16 : sig
     val map : (bitv8 expr -> bitv8 expr) -> t -> t
 

--- a/src/smtml/typed.mli
+++ b/src/smtml/typed.mli
@@ -792,6 +792,8 @@ module Bitv128 : sig
     val map2 : (bitv8 expr -> bitv8 expr -> bitv8 expr) -> t -> t -> t
 
     val eq : t -> t -> t
+
+    val splat : bitv8 expr -> t
   end
 
   module I16x8 : sig
@@ -800,6 +802,8 @@ module Bitv128 : sig
     val map2 : (bitv16 expr -> bitv16 expr -> bitv16 expr) -> t -> t -> t
 
     val eq : t -> t -> t
+
+    val splat : bitv16 expr -> t
   end
 
   module I32x4 : sig
@@ -808,6 +812,8 @@ module Bitv128 : sig
     val map2 : (bitv32 expr -> bitv32 expr -> bitv32 expr) -> t -> t -> t
 
     val eq : t -> t -> t
+
+    val splat : bitv32 expr -> t
   end
 
   module I64x2 : sig
@@ -816,6 +822,8 @@ module Bitv128 : sig
     val map2 : (bitv64 expr -> bitv64 expr -> bitv64 expr) -> t -> t -> t
 
     val eq : t -> t -> t
+
+    val splat : bitv64 expr -> t
   end
 end
 

--- a/src/smtml/typed.mli
+++ b/src/smtml/typed.mli
@@ -794,6 +794,10 @@ module Bitv128 : sig
     val eq : t -> t -> t
 
     val splat : bitv8 expr -> t
+
+    val add : t -> t -> t
+
+    val sub : t -> t -> t
   end
 
   module I16x8 : sig
@@ -804,6 +808,10 @@ module Bitv128 : sig
     val eq : t -> t -> t
 
     val splat : bitv16 expr -> t
+
+    val add : t -> t -> t
+
+    val sub : t -> t -> t
   end
 
   module I32x4 : sig
@@ -814,6 +822,10 @@ module Bitv128 : sig
     val eq : t -> t -> t
 
     val splat : bitv32 expr -> t
+
+    val add : t -> t -> t
+
+    val sub : t -> t -> t
   end
 
   module I64x2 : sig
@@ -824,6 +836,10 @@ module Bitv128 : sig
     val eq : t -> t -> t
 
     val splat : bitv64 expr -> t
+
+    val add : t -> t -> t
+
+    val sub : t -> t -> t
   end
 end
 

--- a/src/smtml/typed.mli
+++ b/src/smtml/typed.mli
@@ -785,6 +785,38 @@ module Bitv128 : sig
 
   (** [to_i64x2] splits the 128-bit vector into two 64-bit terms. *)
   val to_i64x2 : t -> bitv64 expr * bitv64 expr
+
+  module I8x16 : sig
+    val map : (bitv8 expr -> bitv8 expr) -> t -> t
+
+    val map2 : (bitv8 expr -> bitv8 expr -> bitv8 expr) -> t -> t -> t
+
+    val eq : t -> t -> t
+  end
+
+  module I16x8 : sig
+    val map : (bitv16 expr -> bitv16 expr) -> t -> t
+
+    val map2 : (bitv16 expr -> bitv16 expr -> bitv16 expr) -> t -> t -> t
+
+    val eq : t -> t -> t
+  end
+
+  module I32x4 : sig
+    val map : (bitv32 expr -> bitv32 expr) -> t -> t
+
+    val map2 : (bitv32 expr -> bitv32 expr -> bitv32 expr) -> t -> t -> t
+
+    val eq : t -> t -> t
+  end
+
+  module I64x2 : sig
+    val map : (bitv64 expr -> bitv64 expr) -> t -> t
+
+    val map2 : (bitv64 expr -> bitv64 expr -> bitv64 expr) -> t -> t -> t
+
+    val eq : t -> t -> t
+  end
 end
 
 module Float32 : sig

--- a/src/smtml/typed.mli
+++ b/src/smtml/typed.mli
@@ -791,11 +791,17 @@ module Bitv128 : sig
   module I8x16 : sig
     val map : (bitv8 expr -> bitv8 expr) -> t -> t
 
+    val mapi : (int -> bitv8 expr -> bitv8 expr) -> t -> t
+
     val map2 : (bitv8 expr -> bitv8 expr -> bitv8 expr) -> t -> t -> t
+
+    val fold_left : ('acc -> bitv8 expr -> 'acc) -> 'acc -> t -> 'acc
 
     val eq : t -> t -> t
 
     val splat : bitv8 expr -> t
+
+    val bitmask : t -> bitv32 expr
 
     val add : t -> t -> t
 
@@ -805,11 +811,17 @@ module Bitv128 : sig
   module I16x8 : sig
     val map : (bitv16 expr -> bitv16 expr) -> t -> t
 
+    val mapi : (int -> bitv16 expr -> bitv16 expr) -> t -> t
+
     val map2 : (bitv16 expr -> bitv16 expr -> bitv16 expr) -> t -> t -> t
+
+    val fold_left : ('acc -> bitv16 expr -> 'acc) -> 'acc -> t -> 'acc
 
     val eq : t -> t -> t
 
     val splat : bitv16 expr -> t
+
+    val bitmask : t -> bitv32 expr
 
     val add : t -> t -> t
 
@@ -819,11 +831,17 @@ module Bitv128 : sig
   module I32x4 : sig
     val map : (bitv32 expr -> bitv32 expr) -> t -> t
 
+    val mapi : (int -> bitv32 expr -> bitv32 expr) -> t -> t
+
     val map2 : (bitv32 expr -> bitv32 expr -> bitv32 expr) -> t -> t -> t
+
+    val fold_left : ('acc -> bitv32 expr -> 'acc) -> 'acc -> t -> 'acc
 
     val eq : t -> t -> t
 
     val splat : bitv32 expr -> t
+
+    val bitmask : t -> bitv32 expr
 
     val add : t -> t -> t
 
@@ -833,11 +851,17 @@ module Bitv128 : sig
   module I64x2 : sig
     val map : (bitv64 expr -> bitv64 expr) -> t -> t
 
+    val mapi : (int -> bitv64 expr -> bitv64 expr) -> t -> t
+
     val map2 : (bitv64 expr -> bitv64 expr -> bitv64 expr) -> t -> t -> t
+
+    val fold_left : ('acc -> bitv64 expr -> 'acc) -> 'acc -> t -> 'acc
 
     val eq : t -> t -> t
 
     val splat : bitv64 expr -> t
+
+    val bitmask : t -> bitv32 expr
 
     val add : t -> t -> t
 


### PR DESCRIPTION
Hi @filipeom,

More SIMD spam. :sweat_smile:

Then, I think it'll only be a matter of calling the `map[2]` functions on the right primitives (as I did for `eq` as an example). And hopefully, this shouldn't be that much code in the end! :)

Do you feel like this is OK to implement it this way? I'm afraid it'd be too painful otherwise. I thought about using lists or arrays, but that would add some overhead and defining only map/map2 once and reusing them for all the remaining functions is not too bad IMO, so I decided that the array/list was not better.