### PR TITLE
Use explicit result return in smtml parsing functions

### DIFF
--- a/src/bin/cmd_run.ml
+++ b/src/bin/cmd_run.ml
@@ -46,19 +46,18 @@ let run (s : Settings.Run.t) =
     incr total_tests;
     let start_t = Unix.gettimeofday () in
     let ast =
-      try Ok (Compile.until_rewrite file) with
-      | Parse.Syntax_error err -> Error (`Parsing_error (file, err))
-      | Smtml.Eval.Eval_error err -> Error (`Eval_error err)
+      try Compile.until_rewrite file
+      with Smtml.Eval.Eval_error err -> Error (`Eval_error err)
     in
     let state =
       match ast with
       | Ok _ when s.dry -> state
       | Ok ast ->
         Some (Interpret.start ?state ast ~no_strict_status:s.no_strict_status)
-      | Error (`Parsing_error ((fpath, err_msg) as err)) ->
-        Log.err (fun k -> k "%a: %s" Fpath.pp fpath err_msg);
+      | Error (`Msg msg) ->
+        Log.err (fun k -> k "%a: %s" Fpath.pp file msg);
         incr exception_count;
-        exception_log := err :: !exception_log;
+        exception_log := (file, msg) :: !exception_log;
         state
       | Error (`Eval_error kind) ->
         Log.err (fun k ->

--- a/src/bin/cmd_smtzilla.ml
+++ b/src/bin/cmd_smtzilla.ml
@@ -83,11 +83,11 @@ let predictor_conv =
     match String.lowercase_ascii s with
     | "gradient-boost" | "gb" -> Ok GradientBoost
     | "decision-tree" | "dt" -> Ok DecisionTree
-    | _ -> Error (`Msg (Printf.sprintf "Unknown model type: %s" s))
+    | _ -> Fmt.error_msg "Unknown model type: %s" s
   in
   let print ppf = function
-    | GradientBoost -> Format.fprintf ppf "gradient-boost"
-    | DecisionTree -> Format.fprintf ppf "decision-tree"
+    | GradientBoost -> Fmt.pf ppf "gradient-boost"
+    | DecisionTree -> Fmt.pf ppf "decision-tree"
   in
   Arg.conv (parse, print)
 
@@ -99,7 +99,7 @@ let pos_int =
     | Some i when i > 0 -> Ok i
     | None | Some _ -> Fmt.error_msg "Expected a positive integer"
   in
-  Arg.conv (parser, Format.pp_print_int)
+  Arg.conv (parser, Fmt.int)
 
 let n_estimators =
   let doc =

--- a/src/bin/cmd_to_smt2.ml
+++ b/src/bin/cmd_to_smt2.ml
@@ -9,7 +9,11 @@ let run (settings : Settings.To_smt2.t) =
     (val Solver_type.to_mappings settings.solver_type)
   in
   Mappings.set_debug settings.debug;
-  let ast = Parse.from_file settings.filename in
+  let ast =
+    match Parse.from_file settings.filename with
+    | Ok script -> script
+    | Error (`Msg err) -> Fmt.failwith "%s" err
+  in
   let assertions =
     List.filter_map (function Ast.Assert e -> Some e | _ -> None) ast
   in
@@ -17,7 +21,11 @@ let run (settings : Settings.To_smt2.t) =
   Fmt.pr "%a" (Mappings.Smtlib.pp ~name ?logic:None ?status:None) assertions
 
 let run_to_smtml ~filename =
-  let ast = Parse.from_file filename in
+  let ast =
+    match Parse.from_file filename with
+    | Ok script -> script
+    | Error (`Msg err) -> Fmt.failwith "%s" err
+  in
   let assertions =
     List.filter_map (function Ast.Assert e -> Some e | _ -> None) ast
   in

--- a/src/smtml/compile.ml
+++ b/src/smtml/compile.ml
@@ -3,5 +3,6 @@
 (* Written by the Smtml programmers *)
 
 let until_rewrite filename =
-  let script = Parse.from_file filename in
+  let open Result.Syntax in
+  let+ script = Parse.from_file filename in
   Rewrite.rewrite script

--- a/src/smtml/compile.mli
+++ b/src/smtml/compile.mli
@@ -11,4 +11,4 @@
 
     [path] is the file path to read and process. The function returns a list of
     AST nodes resulting from the rewrite process. *)
-val until_rewrite : Fpath.t -> Ast.t list
+val until_rewrite : Fpath.t -> (Ast.t list, [> `Msg of string ]) result

--- a/src/smtml/logic.ml
+++ b/src/smtml/logic.ml
@@ -88,4 +88,4 @@ let of_string logic =
   | "QF_UFNRA" -> Ok QF_UFNRA
   | "UFLRA" -> Ok UFLRA
   | "UFNIA" -> Ok UFNIA
-  | _ -> Error (`Msg (Fmt.str "unknown logic %s" logic))
+  | _ -> Fmt.error_msg "unknown logic %s" logic

--- a/src/smtml/model.ml
+++ b/src/smtml/model.ml
@@ -109,21 +109,21 @@ module Parse = struct
     module Json = Yojson.Safe
 
     let from_json json =
-      let symbols = Json.Util.member "model" json |> Json.Util.to_assoc in
       let tbl = Hashtbl.create 16 in
       let* () =
+        let symbols = Json.Util.member "model" json |> Json.Util.to_assoc in
         Result.list_iter
           (fun (symbol, json) ->
             let ty = Json.Util.member "ty" json |> Json.Util.to_string in
             let* ty = Ty.of_string ty in
-            let value =
-              (* FIXME: this is a bit hackish in order to reuse the previous code *)
+            let* value =
               match Json.Util.member "value" json with
-              | `Bool x -> Bool.to_string x
-              | `Float x -> Float.to_string x
-              | `Int x -> Int.to_string x
-              | `String x -> x
-              | _ -> assert false
+              | `Bool x -> Ok (Bool.to_string x)
+              | `Float x -> Ok (Float.to_string x)
+              | `Int x -> Ok (Int.to_string x)
+              | `String x -> Ok x
+              | invalid ->
+                Fmt.error_msg "Invalid json value: %a" Json.pp invalid
             in
             let+ value = Value.of_string ty value in
             let key = Symbol.make ty symbol in
@@ -132,13 +132,27 @@ module Parse = struct
       in
       Ok tbl
 
-    let from_string s = Json.from_string s |> from_json
+    let from_string s =
+      let* model =
+        try Ok (Json.from_string s)
+        with Yojson.Json_error msg -> Fmt.error_msg "invalid json: %s" msg
+      in
+      from_json model
 
-    let from_channel chan = Json.from_channel chan |> from_json
+    let from_channel chan =
+      let* model =
+        try Ok (Json.from_channel chan)
+        with Yojson.Json_error msg -> Fmt.error_msg "invalid json: %s" msg
+      in
+      from_json model
 
     let from_file file =
       let file = Fpath.to_string file in
-      Json.from_file ~fname:file file |> from_json
+      let* model =
+        try Ok (Json.from_file ~fname:file file)
+        with Yojson.Json_error msg -> Fmt.error_msg "invalid json: %s" msg
+      in
+      from_json model
   end
 
   module Scfg = struct

--- a/src/smtml/parse.ml
+++ b/src/smtml/parse.ml
@@ -2,8 +2,6 @@
 (* Copyright (C) 2023-2026 formalsec *)
 (* Written by the Smtml programmers *)
 
-exception Syntax_error of string
-
 module Smtml = struct
   open Lexer
   open Lexing
@@ -14,15 +12,14 @@ module Smtml = struct
       (pos.pos_cnum - pos.pos_bol + 1)
 
   let parse_with_error parser lexbuf =
-    try parser Lexer.token lexbuf with
-    | SyntaxError msg ->
-      raise (Syntax_error (Fmt.str "%a: %s" pp_pos lexbuf msg))
-    | Parser.Error ->
-      raise (Syntax_error (Fmt.str "%a: syntax error" pp_pos lexbuf))
+    try Ok (parser Lexer.token lexbuf) with
+    | SyntaxError msg -> Fmt.error_msg "%a: %s" pp_pos lexbuf msg
+    | Parser.Error -> Fmt.error_msg "%a: syntax error" pp_pos lexbuf
 
   module Script = struct
     let from_file filename =
-      let res =
+      let open Result.Syntax in
+      let* result =
         Bos.OS.File.with_ic filename
           (fun chan () ->
             let lexbuf = Lexing.from_channel chan in
@@ -31,7 +28,7 @@ module Smtml = struct
             parse_with_error Parser.script lexbuf )
           ()
       in
-      match res with Error (`Msg e) -> Fmt.failwith "%s" e | Ok v -> v
+      result
 
     let from_string contents =
       parse_with_error Parser.script (Lexing.from_string contents)
@@ -39,7 +36,8 @@ module Smtml = struct
 
   module Expr = struct
     let from_file filename =
-      let res =
+      let open Result.Syntax in
+      let* result =
         Bos.OS.File.with_ic filename
           (fun chan () ->
             let lexbuf = Lexing.from_channel chan in
@@ -48,7 +46,7 @@ module Smtml = struct
             parse_with_error Parser.expression lexbuf )
           ()
       in
-      match res with Error (`Msg e) -> Fmt.failwith "%s" e | Ok v -> v
+      result
 
     let from_string contents =
       parse_with_error Parser.expression (Lexing.from_string contents)
@@ -59,18 +57,12 @@ module Smtlib = struct
   let from_file filename =
     try
       let _, st = Smtlib.parse_all (`File (Fpath.to_string filename)) in
-      Lazy.force st
+      Ok (Lazy.force st)
     with
     | Dolmen.Std.Loc.Syntax_error (loc, `Regular msg) ->
-      raise
-        (Syntax_error
-           (Fmt.str "%a: syntax error: %t" Dolmen.Std.Loc.print_compact loc msg)
-        )
+      Fmt.error_msg "%a: syntax error: %t" Dolmen.Std.Loc.print_compact loc msg
     | Dolmen.Std.Loc.Syntax_error (loc, `Advanced (x, _, _, _)) ->
-      raise
-        (Syntax_error
-           (Fmt.str "%a: syntax error: %s" Dolmen.Std.Loc.print_compact loc x)
-        )
+      Fmt.error_msg "%a: syntax error: %s" Dolmen.Std.Loc.print_compact loc x
 end
 
 let from_file filename =

--- a/src/smtml/parse.mli
+++ b/src/smtml/parse.mli
@@ -8,27 +8,24 @@
 
 (** {1 Exceptions} *)
 
-(** Exception raised when a syntax error occurs during parsing. *)
-exception Syntax_error of string
-
 (** {1 Smt.ml Parsing} *)
 
 module Smtml : sig
   module Script : sig
     (** [from_file file] parses an SMT-ML script from the given [file]. *)
-    val from_file : Fpath.t -> Ast.Script.t
+    val from_file : Fpath.t -> (Ast.Script.t, [> `Msg of string ]) result
 
     (** [from_string s] parses an SMT-ML script from the given string [s]. *)
-    val from_string : string -> Ast.Script.t
+    val from_string : string -> (Ast.Script.t, [> `Msg of string ]) result
   end
 
   module Expr : sig
     (** [from_file file] parses an SMT-ML expression from the given [file]. *)
-    val from_file : Fpath.t -> Expr.t
+    val from_file : Fpath.t -> (Expr.t, [> `Msg of string ]) result
 
     (** [from_string s] parses an SMT-ML expression from the given string [s].
     *)
-    val from_string : string -> Expr.t
+    val from_string : string -> (Expr.t, [> `Msg of string ]) result
   end
 end
 
@@ -37,11 +34,11 @@ end
 module Smtlib : sig
   (** [from_file file] parses an SMT-LIB compliant script from the given [file].
   *)
-  val from_file : Fpath.t -> Ast.Script.t
+  val from_file : Fpath.t -> (Ast.Script.t, [> `Msg of string ]) result
 end
 
 (** {1 Generic Parsing} *)
 
 (** [from_file file] attempts to parse an SMT-ML (.smtml) or SMT-LIB (.smt2)
     script based on the file extension of [file]. *)
-val from_file : Fpath.t -> Ast.Script.t
+val from_file : Fpath.t -> (Ast.Script.t, [> `Msg of string ]) result

--- a/src/smtml/solver_mode.ml
+++ b/src/smtml/solver_mode.ml
@@ -16,6 +16,6 @@ let of_string = function
   | "batch" -> Ok Batch
   | "cached" -> Ok Cached
   | "incremental" -> Ok Incremental
-  | _mode -> Error (`Msg (Fmt.str "unknown prover mode"))
+  | mode -> Fmt.error_msg "unknown prover mode: %s" mode
 
 let conv = Cmdliner.Arg.conv (of_string, pp)

--- a/src/smtml/solver_type.ml
+++ b/src/smtml/solver_type.ml
@@ -21,7 +21,7 @@ let of_string s =
   | "cvc5" -> Ok Cvc5_solver
   | "alt-ergo" -> Ok Altergo_solver
   | "smtzilla" -> Ok Smtzilla_solver
-  | s -> Error (`Msg (Fmt.str "unknown solver %s" s))
+  | s -> Fmt.error_msg "unknown solver %s" s
 
 let pp fmt = function
   | Z3_solver -> Fmt.string fmt "Z3"

--- a/test/benchmarks/test_collections_c.ml
+++ b/test/benchmarks/test_collections_c.ml
@@ -13,7 +13,7 @@ let benchmarks =
   |> Result.get_ok
 
 let make_test path _ =
-  let script = Smtml.Compile.until_rewrite path in
+  let script = Smtml.Compile.until_rewrite path |> Result.get_ok in
   let _ = Interpreter.start ~no_strict_status:true ~quiet:true script in
   ()
 

--- a/test/cli/smt2/test_smt2.t
+++ b/test/cli/smt2/test_smt2.t
@@ -113,9 +113,9 @@ Test status tracking:
          Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
          Called from Smtml__Interpret.Make.eval in file "src/smtml/interpret.ml", lines 65-66, characters 12-46
          Called from Smtml__Interpret.Make.loop in file "src/smtml/interpret.ml", line 110, characters 8-65
-         Called from Dune__exe__Cmd_run.run.run_file in file "src/bin/cmd_run.ml", line 57, characters 13-78
+         Called from Dune__exe__Cmd_run.run.run_file in file "src/bin/cmd_run.ml", line 56, characters 13-78
          Called from Stdlib__List.fold_left in file "list.ml", line 125, characters 24-34
-         Called from Dune__exe__Cmd_run.run in file "src/bin/cmd_run.ml", line 103, characters 14-54
+         Called from Dune__exe__Cmd_run.run in file "src/bin/cmd_run.ml", line 102, characters 14-54
          Called from Cmdliner_term.app.(fun) in file "cmdliner_term.ml", line 22, characters 19-24
          Called from Cmdliner_eval.run_parser in file "cmdliner_eval.ml", line 41, characters 7-16
   [125]

--- a/test/unit/test_expr.ml
+++ b/test/unit/test_expr.ml
@@ -850,7 +850,7 @@ let test_printer _ =
   let y = Expr.symbol (Symbol.make ty "y") in
   let e = Expr.binop ty Add x y in
   let serialized = Fmt.str "%a" Expr.Printer.pp_expr e in
-  let parsed = Parse.Smtml.Expr.from_string serialized in
+  let parsed = Parse.Smtml.Expr.from_string serialized |> Result.get_ok in
   check e parsed
 
 let test_printer_query _ =
@@ -859,7 +859,7 @@ let test_printer_query _ =
   let y = Expr.symbol (Symbol.make ty "y") in
   let e = Expr.binop ty Add x y in
   let serialized = Fmt.str "%a" Expr.Printer.pp_query [ e ] in
-  let script = Parse.Smtml.Script.from_string serialized in
+  let script = Parse.Smtml.Script.from_string serialized |> Result.get_ok in
   assert (List.length script = 4)
 
 let test_suite =


### PR DESCRIPTION
It already bit me in the ass by not treating exceptions in injector. With explicit types I'm forced to treat them and also it allows me to use monadic syntax.