### PR TITLE
Cancel CI jobs when branch is updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - main
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Uses a GitHub Actions concurrency group keyed by the workflow and branch reference. When a new push arrives, it cancels any in-progress runs for that same PR branch before starting the new one.

Prevents wasted runner time on outdated commits and, more importantly, saves precious liters of water to cool our AI overlords.