### PR TITLE
Allow mdx blocks to execute if you have at least z3 installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ $ bisect-ppx-report html    # Detailed Report in _coverage/index.html
 ## Quick Start
 
 ```ocaml
-# #require "smtml";;
 # open Smtml;;
 # #install_printer Expr.pp;;
 # #install_printer Value.pp;;

--- a/docs/dune
+++ b/docs/dune
@@ -5,11 +5,6 @@
  (deps
   (source_tree examples)
   ./examples/product_mix.exe)
- (enabled_if
-  (and
-   %{lib-available:z3}
-   (not %{lib-available:alt-ergo-lib})
-   (not %{lib-available:bitwuzla-cxx})
-   (not %{lib-available:colibri2.core})
-   (not %{lib-available:cvc5})))
+ (libraries smtml smtml.prelude zarith fmt)
+ (enabled_if %{lib-available:z3})
  (files :standard - *.mld))

--- a/docs/index.mld
+++ b/docs/index.mld
@@ -20,7 +20,6 @@ opam install smtml
 
 Basic usage in OCaml toplevel:
 {@ocaml[
-# #require "smtml";;
 # #install_printer Smtml.Expr.pp;;
 # let pp_model = Smtml.Model.pp ~no_values:false;;
 val pp_model : Smtml.Model.t Fmt.t = <fun>

--- a/dune
+++ b/dune
@@ -1,11 +1,6 @@
 (mdx
- (enabled_if
-  (and
-   %{lib-available:z3}
-   (not %{lib-available:alt-ergo-lib})
-   (not %{lib-available:bitwuzla-cxx})
-   (not %{lib-available:colibri2.core})
-   (not %{lib-available:cvc5}))))
+ (libraries smtml smtml.prelude zarith fmt)
+ (enabled_if %{lib-available:z3}))
 
 (env
  (release


### PR DESCRIPTION
Fixes the issue where mdx blocks would only run when z3 was the only solver installed. This allows us to verify changes in mdx blocks with any combination of solvers installed. Provided that at least one of them contains z3.

Closes #565