### PR TITLE
Fix model recovery from Alt-Ergo for negative values

### DIFF
--- a/src/smtml/altergo_mappings.default.ml
+++ b/src/smtml/altergo_mappings.default.ml
@@ -183,6 +183,15 @@ module M = struct
         | { f = Int z; _ } -> DM.Int.mk z
         | { f = Real q; _ } -> DM.Real.mk q
         | { f = Bitv (n, z); _ } -> DM.Bitv.mk n z
+        | { f = Op Minus; xs = [ a; b ]; _ } -> (
+          match (AEL.Expr.term_view a, AEL.Expr.term_view b) with
+          | { f = Int za; _ }, { f = Int zb; _ } when Z.equal za Z.zero ->
+            DM.Int.mk (Z.neg zb)
+          | { f = Real qa; _ }, { f = Real qb; _ } when Q.equal qa Q.zero ->
+            DM.Real.mk (Q.neg qb)
+          | _ ->
+            Fmt.failwith "Altergo_mappings: ae_expr_to_dvalue(%a)"
+              AEL.Expr.print e )
         | _ ->
           Fmt.failwith "Altergo_mappings: ae_expr_to_dvalue(%a)" AEL.Expr.print
             e

--- a/test/cli/regression/dune
+++ b/test/cli/regression/dune
@@ -12,3 +12,9 @@
  (applies_to test_issue_183)
  (enabled_if
   (not %{lib-available:colibri2.core})))
+
+(cram
+ (applies_to test_pr677)
+ (enabled_if
+  (and %{lib-available:alt-ergo-lib}))
+ (deps %{bin:smtml} test_pr677.smt2))

--- a/test/cli/regression/test_pr677.smt2
+++ b/test/cli/regression/test_pr677.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_LIA)
+(declare-const x Int)
+(assert (= x (- 1)))
+(check-sat)
+(get-model)

--- a/test/cli/regression/test_pr677.t
+++ b/test/cli/regression/test_pr677.t
@@ -1,0 +1,4 @@
+  $ smtml run --solver alt-ergo test_pr677.smt2
+  sat
+  (model
+    (x int -1))


### PR DESCRIPTION
For some reason (- x) is produced as (0 - x).