### PR TITLE
FIx handling of uninterpreted function by Alt-Ergo and Colibri2

### DIFF
--- a/src/smtml/altergo_mappings.default.ml
+++ b/src/smtml/altergo_mappings.default.ml
@@ -197,18 +197,24 @@ module M = struct
 
       let mk_model ~ctx model =
         AEL.ModelMap.fold
-          (fun ((hs, _, _) as id) g acc ->
-            let e = cgraph_to_value hs g in
-            let sym = aeid_to_sym id in
-            let tcst =
-              match
-                ( Symbol.Map.find_opt sym ctx
-                  : (term, func_decl) Mappings_intf.decl option )
-              with
-              | Some (Sym { term_descr = Cst c; _ }) -> c
-              | _ -> assert false
-            in
-            ConstMap.add tcst (ae_expr_to_dvalue e) acc )
+          (fun ((hs, tyl, _) as id) g acc ->
+            match tyl with
+            | _ :: _ ->
+              (* Skipping uninterpreted functions because we don't support their
+                 models yet *)
+              acc
+            | [] ->
+              let e = cgraph_to_value hs g in
+              let sym = aeid_to_sym id in
+              let tcst =
+                match
+                  ( Symbol.Map.find_opt sym ctx
+                    : (term, func_decl) Mappings_intf.decl option )
+                with
+                | Some (Sym { term_descr = Cst c; _ }) -> c
+                | _ -> assert false
+              in
+              ConstMap.add tcst (ae_expr_to_dvalue e) acc )
           model ConstMap.empty
 
       let check ?(ctx = Symbol.Map.empty) (s : solver) ~(assumptions : term list)

--- a/src/smtml/altergo_mappings.default.ml
+++ b/src/smtml/altergo_mappings.default.ml
@@ -3,14 +3,12 @@
 (* Written by Hichem Rami Ait El Hara *)
 
 module M = struct
-  open Dolmenexpr_to_expr
   module AEL = AltErgoLib
   module Frontend = AEL.Frontend
   module C = AEL.Commands
   module Sat_solver_sig = AEL.Sat_solver_sig
   module Sat_solver = AEL.Sat_solver
   module DStd = Dolmen_std
-  module DBuiltin = DStd.Builtin
   module DM = Dolmen_model
 
   module ConstSet = Set.Make (struct
@@ -123,10 +121,11 @@ module M = struct
 
       let get_new_syms ctx =
         Symbol.Map.fold
-          (fun _ t acc ->
-            match (t : DTerm.t) with
-            | { term_descr = Cst c; _ } -> ConstSet.add c acc
-            | _ -> acc )
+          (fun _ (d : (term, func_decl) Mappings_intf.decl) acc ->
+            match d with
+            | Sym { term_descr = Cst c; _ } -> ConstSet.add c acc
+            | Func c -> ConstSet.add c acc
+            | Sym _ -> acc )
           ctx ConstSet.empty
 
       let add ?(ctx = Symbol.Map.empty) (s : solver) (el : term list) : unit =
@@ -202,8 +201,11 @@ module M = struct
             let e = cgraph_to_value hs g in
             let sym = aeid_to_sym id in
             let tcst =
-              match (Symbol.Map.find_opt sym ctx : DTerm.t option) with
-              | Some { term_descr = Cst c; _ } -> c
+              match
+                ( Symbol.Map.find_opt sym ctx
+                  : (term, func_decl) Mappings_intf.decl option )
+              with
+              | Some (Sym { term_descr = Cst c; _ }) -> c
               | _ -> assert false
             in
             ConstMap.add tcst (ae_expr_to_dvalue e) acc )

--- a/src/smtml/colibri2_mappings.default.ml
+++ b/src/smtml/colibri2_mappings.default.ml
@@ -144,8 +144,10 @@ module M = struct
               (fun _ (d : (term, func_decl) Mappings_intf.decl) acc ->
                 match d with
                 | Sym { term_descr = Cst c; _ } -> ConstSet.add c acc
-                | Sym _ -> acc
-                | Func c -> ConstSet.add c acc )
+                | _ -> acc
+              (* Skipping uninterpreted functions because we don't support their
+                 models yet *)
+                )
               ctx ConstSet.empty )
           ctx
 

--- a/src/smtml/colibri2_mappings.default.ml
+++ b/src/smtml/colibri2_mappings.default.ml
@@ -145,9 +145,8 @@ module M = struct
                 match d with
                 | Sym { term_descr = Cst c; _ } -> ConstSet.add c acc
                 | _ -> acc
-              (* Skipping uninterpreted functions because we don't support their
-                 models yet *)
-                )
+                (* Skipping uninterpreted functions because we don't support their
+                 models yet *) )
               ctx ConstSet.empty )
           ctx
 

--- a/src/smtml/colibri2_mappings.default.ml
+++ b/src/smtml/colibri2_mappings.default.ml
@@ -141,10 +141,11 @@ module M = struct
         Option.fold ~none:ConstSet.empty
           ~some:(fun ctx ->
             Symbol.Map.fold
-              (fun _ t acc ->
-                match (t : DTerm.t) with
-                | { term_descr = Cst c; _ } -> ConstSet.add c acc
-                | _ -> acc )
+              (fun _ (d : (term, func_decl) Mappings_intf.decl) acc ->
+                match d with
+                | Sym { term_descr = Cst c; _ } -> ConstSet.add c acc
+                | Sym _ -> acc
+                | Func c -> ConstSet.add c acc )
               ctx ConstSet.empty )
           ctx
 

--- a/src/smtml/dolmenexpr_to_expr.ml
+++ b/src/smtml/dolmenexpr_to_expr.ml
@@ -517,13 +517,14 @@ module DolmenIntf = struct
       in
       let m =
         Symbol.Map.fold
-          (fun _ (t : term) acc ->
-            match t with
-            | { term_descr = Cst c; _ } -> (
+          (fun _ (d : (term, func_decl) Mappings_intf.decl) acc ->
+            match d with
+            | Sym { term_descr = Cst c; _ } -> (
               match DM.Model.Cst.find_opt c acc with
               | Some _ -> acc
               | None -> DM.Model.Cst.add c (get_defval c) acc )
-            | _ -> assert false )
+            | Func _ -> acc
+            | Sym _ -> assert false )
           ctx m
       in
       let env =

--- a/src/smtml/dolmenexpr_to_expr.mli
+++ b/src/smtml/dolmenexpr_to_expr.mli
@@ -440,8 +440,11 @@ module DolmenIntf : sig
     (** [get_symbols model] retrieves the list of symbols in the model. *)
     val get_symbols : model -> Symbol.t list
 
-    (** [eval ?completion model t] evaluates the term [t] in the given [model].
-        If [completion] is true, missing values are completed. *)
+    (** [eval ?ctx ?completion model t] evaluates the term [t] in the given [model].
+        If [completion] is true, missing values are completed.
+        [ctx] maps every symbol to its corresponding term or function, its used
+        to assign complete the model by assigning values to declared but
+        uncontrained symbols. *)
     val eval :
          ?ctx:(term, func_decl) Mappings_intf.decl Symbol.Map.t
       -> ?completion:bool

--- a/src/smtml/dolmenexpr_to_expr.mli
+++ b/src/smtml/dolmenexpr_to_expr.mli
@@ -443,7 +443,7 @@ module DolmenIntf : sig
     (** [eval ?completion model t] evaluates the term [t] in the given [model].
         If [completion] is true, missing values are completed. *)
     val eval :
-         ?ctx:term Symbol.Map.t
+         ?ctx:(term, func_decl) Mappings_intf.decl Symbol.Map.t
       -> ?completion:bool
       -> model
       -> term

--- a/src/smtml/dolmenexpr_to_expr.mli
+++ b/src/smtml/dolmenexpr_to_expr.mli
@@ -440,10 +440,10 @@ module DolmenIntf : sig
     (** [get_symbols model] retrieves the list of symbols in the model. *)
     val get_symbols : model -> Symbol.t list
 
-    (** [eval ?ctx ?completion model t] evaluates the term [t] in the given [model].
-        If [completion] is true, missing values are completed.
-        [ctx] maps every symbol to its corresponding term or function, its used
-        to assign complete the model by assigning values to declared but
+    (** [eval ?ctx ?completion model t] evaluates the term [t] in the given
+        [model]. If [completion] is true, missing values are completed. [ctx]
+        maps every symbol to its corresponding term or function, its used to
+        assign complete the model by assigning values to declared but
         uncontrained symbols. *)
     val eval :
          ?ctx:(term, func_decl) Mappings_intf.decl Symbol.Map.t

--- a/src/smtml/mappings.ml
+++ b/src/smtml/mappings.ml
@@ -882,8 +882,13 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
       | Some symbols ->
         List.iter
           (fun sym ->
-            let v = value model0 (Expr.symbol sym) in
-            Hashtbl.add m sym v )
+            match Smap.find_opt sym ctx with
+            | Some (Func _) ->
+              (* TODO: support models/values for uninterpreted functions *)
+              ()
+            | Some (Sym _) | None ->
+              let v = value model0 (Expr.symbol sym) in
+              Hashtbl.add m sym v )
           symbols
       | None ->
         Smap.iter

--- a/src/smtml/mappings.ml
+++ b/src/smtml/mappings.ml
@@ -11,7 +11,7 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
     open Ty
     module Smap = Symbol.Map
 
-    type symbol_ctx = M.term Smap.t
+    type symbol_ctx = (M.term, M.func_decl) decl Smap.t
 
     module Encoder = struct
       let i8 = M.Types.bitv 8
@@ -59,23 +59,23 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
         in
         if M.Internals.caches_consts then
           let sym = M.const name (get_type s.ty) in
-          (Smap.add s sym ctx, sym)
+          (Smap.add s (Sym sym) ctx, sym)
         else
           match Smap.find_opt s ctx with
-          | Some sym -> (ctx, sym)
-          | None ->
+          | Some (Sym sym) -> (ctx, sym)
+          | Some (Func _) | None ->
             let sym = M.const name (get_type s.ty) in
-            (Smap.add s sym ctx, sym)
+            (Smap.add s (Sym sym) ctx, sym)
 
       let make_var (ctx : symbol_ctx) (s : Symbol.t) : symbol_ctx * M.term =
         let name =
           match s.name with Simple name -> name | _ -> assert false
         in
         match Smap.find_opt s ctx with
-        | Some sym -> (ctx, sym)
-        | None ->
+        | Some (Sym sym) -> (ctx, sym)
+        | Some (Func _) | None ->
           let var = M.var name (get_type (Symbol.type_of s)) in
-          (Smap.add s var ctx, var)
+          (Smap.add s (Sym var) ctx, var)
 
       module Bool_impl = struct
         let true_ = M.true_
@@ -746,8 +746,16 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
           let ty = get_type @@ Symbol.type_of sym in
           let tys = List.map (fun e -> get_type @@ Expr.ty e) args in
           let ctx, arguments = encode_exprs ctx args in
-          let sym = M.Func.make name tys ty in
-          (ctx, M.Func.apply sym arguments)
+          let ctx, func =
+            match Smap.find_opt sym ctx with
+            | Some (Func func) -> (ctx, func)
+            | Some (Sym _) -> assert false
+            | None ->
+              let func = M.Func.make name tys ty in
+              (Smap.add sym (Func func) ctx, func)
+          in
+          let term = M.Func.apply func arguments in
+          (ctx, term)
         | Unop (ty, op, e) ->
           let ctx, e = encode_expr ctx e in
           (ctx, unop ty op e)
@@ -879,9 +887,14 @@ module Make (M_with_make : M_with_make) : S_with_fresh = struct
           symbols
       | None ->
         Smap.iter
-          (fun (sym : Symbol.t) term ->
-            let v = Encoder.value_of_term ~ctx model sym.ty term in
-            Hashtbl.add m sym v )
+          (fun (sym : Symbol.t) decl ->
+            match decl with
+            | Func _ ->
+              (* TODO: support models/values for uninterpreted functions *)
+              ()
+            | Sym term ->
+              let v = Encoder.value_of_term ~ctx model sym.ty term in
+              Hashtbl.add m sym v )
           ctx );
       m
 

--- a/src/smtml/mappings_intf.ml
+++ b/src/smtml/mappings_intf.ml
@@ -7,6 +7,10 @@
     optimization. It provides a generic interface for working with different SMT
     solvers and their functionalities. *)
 
+type ('term, 'func_decl) decl =
+  | Sym of 'term
+  | Func of 'func_decl
+
 (** {1 Module Types} *)
 
 (** The [M] module type defines the core interface for interacting with SMT
@@ -768,7 +772,7 @@ module type M = sig
     (** [eval ?completion model t] evaluates the term [t] in the given [model].
         If [completion] is true, missing values are completed. *)
     val eval :
-         ?ctx:term Symbol.Map.t
+         ?ctx:(term, func_decl) decl Symbol.Map.t
       -> ?completion:bool
       -> model
       -> term
@@ -795,13 +799,14 @@ module type M = sig
     val reset : solver -> unit
 
     (** [add solver ts] adds the terms [ts] to the solver [solver]. *)
-    val add : ?ctx:term Symbol.Map.t -> solver -> term list -> unit
+    val add :
+      ?ctx:(term, func_decl) decl Symbol.Map.t -> solver -> term list -> unit
 
     (** [check solver ~assumptions] checks the satisfiability of the solver
         [solver] with the given [assumptions]. Returns [`Sat], [`Unsat], or
         [`Unknown]. *)
     val check :
-         ?ctx:term Symbol.Map.t
+         ?ctx:(term, func_decl) decl Symbol.Map.t
       -> solver
       -> assumptions:term list
       -> [ `Sat | `Unsat | `Unknown ]

--- a/test/cli/regression/dune
+++ b/test/cli/regression/dune
@@ -18,3 +18,9 @@
  (enabled_if
   (and %{lib-available:alt-ergo-lib}))
  (deps %{bin:smtml} test_pr677.smt2))
+
+(cram
+ (applies_to test_pr678)
+ (enabled_if
+  (and %{lib-available:colibri2.core} %{lib-available:alt-ergo-lib}))
+ (deps %{bin:smtml} test_pr678.smt2))

--- a/test/cli/regression/test_pr678.smt2
+++ b/test/cli/regression/test_pr678.smt2
@@ -1,0 +1,6 @@
+(set-logic QF_UFLIA)
+(declare-fun f (Int Int) Bool)
+(assert (f 1 2))
+(assert (f 2 3))
+(assert (not (and (f 1 2) (f 2 3))))
+(check-sat)

--- a/test/cli/regression/test_pr678.t
+++ b/test/cli/regression/test_pr678.t
@@ -1,0 +1,6 @@
+
+  $ smtml run --solver colibri2 test_pr678.smt2
+  unsat
+
+  $ smtml run --solver alt-ergo test_pr678.smt2
+  unsat


### PR DESCRIPTION
The idea is to simply store uninterpreted functions in the context (same as we do for uninterpreted symbols), so that we can declare for alt-ergo notably.

I encountered this issue while looking at an error that @stevendeo encountered while trying to use smtml with Alt-Ergo
